### PR TITLE
Deploy Smart Contracts on NEAR's Aurora Testnet

### DIFF
--- a/MedETH/README.md
+++ b/MedETH/README.md
@@ -165,6 +165,10 @@ make deploy-doctor ARGS="--network scroll"
 * Filecoin Calibration Testnet
     - UserSide: [0xB9D4F7F14E5281A214aF74787b01508062CCd2Df](https://calibration.filfox.info/en/address/0xB9D4F7F14E5281A214aF74787b01508062CCd2Df)
     - DoctorSide: [0xC1aF668bBF21a2170017f07757726BebB063238a](https://calibration.filfox.info/en/address/0xC1aF668bBF21a2170017f07757726BebB063238a)
+  
+* NEAR's Aurora Testnet
+    - UserSide: [0x7F03597Ec06E419b87B0d51138B9Dd809593Fcc8](https://explorer.testnet.aurora.dev/address/0x7F03597Ec06E419b87B0d51138B9Dd809593Fcc8)
+    - DoctorSide: [0x57214C3497Ef0A5af63048fD01023dF2736266f0](https://explorer.testnet.aurora.dev/address/0x57214C3497Ef0A5af63048fD01023dF2736266f0)
 
 
 ## Frontend Setup

--- a/Medi_Token/README.md
+++ b/Medi_Token/README.md
@@ -125,3 +125,4 @@ make deploy ARGS="--network scroll"
 * Polygon Cardona: [0x4216a9c6EB59FcA323169Ef3194783d3dC9b7F23](https://cardona-zkevm.polygonscan.com/address/0x4216a9c6EB59FcA323169Ef3194783d3dC9b7F23)
 * Scroll Sepolia: [0x6e650a339AbE4D9cf0aa8091fB2099284968beFf](https://sepolia.scrollscan.com/address/0x6e650a339AbE4D9cf0aa8091fB2099284968beFf)
 * Filecoin Calibration: [0x6b53C44053449B4B9cAdAfe271f9E5cb930446Be](https://calibration.filfox.info/en/address/0x6b53C44053449B4B9cAdAfe271f9E5cb930446Be)
+* NEAR's Aurora Testnet: [0x98E3b760BA19e6ED7d3c67e06B66c13CD07654f2](https://explorer.testnet.aurora.dev/token/0x98E3b760BA19e6ED7d3c67e06B66c13CD07654f2)

--- a/web3-tools-contracts/README.md
+++ b/web3-tools-contracts/README.md
@@ -99,3 +99,4 @@ make deploy ARGS="--network scroll"
 * **Polygon Cardona:** [0x5c1dBee87430956762901f4aaa18367aE7631A21](https://cardona-zkevm.polygonscan.com/address/0x5c1dBee87430956762901f4aaa18367aE7631A21)
 * **Scroll Sepolia:** [0x5B78fbCB2d94e3B1c7Da8eFaA85eB5a2839F905E](https://sepolia.scrollscan.com/address/0x5B78fbCB2d94e3B1c7Da8eFaA85eB5a2839F905E)
 * **Filecoin Calibration:** [0xa8162f65f3b7D3573C9B2812b3f8308cE62914F6](https://calibration.filfox.info/en/address/0xa8162f65f3b7D3573C9B2812b3f8308cE62914F6)
+* **NEAR's Aurora Testnet:** [0x9F470730302CB5D8e8f75BF529055f4772FFcb2E](https://explorer.testnet.aurora.dev/address/0x9F470730302CB5D8e8f75BF529055f4772FFcb2E)


### PR DESCRIPTION
## **Description:**
This PR deploys the MediToken smart contract, DoctorSide and UserSide smart contracts from the MedETH project, and Web3-tools-contracts on NEAR's Aurora Testnet. It includes updates to the README files to incorporate the newly deployed contract addresses for the NEAR's Aurora Testnet.

## **Checklist:**
- [X] Deployed MediToken smart contract on NEAR's Aurora Testnet.
- [X] Deployed DoctorSide and UserSide smart contracts on NEAR's Aurora Testnet.
- [X] Deployed Web3-tools-contracts on NEAR's Aurora Testnet.
- [X] Updated all README files with the deployed contract addresses for NEAR's Aurora Testnet.

Resolves #24 
