### PR TITLE
docs: add contributor onboarding and entry point guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ Our core platform, **EMTTR (Electronic Medicine Trial and Test Records)**, provi
 
 ---
 
+## Getting started (For Developers)
+
+This repository contains multiple sub-projects.
+
+If you're looking to quickly run a working part of the project, you can try one of the available modules such as:
+
+## Run the frontend (medical-billing)
+
+cd ZKMedical-Billing/medical-billing
+npm install
+npm start
+
+This will start a local deployement server at:
+http://localhost:3000
+
+### Impportant notes
+
+-Do not run `npm install` at the root of the repository.
+-Each sub-projects has its own dependencies and setup instructions.
+-Other modules(example- ZK velidation,contracts)may require additional configuration and can be explored seperately.
 ## 💾 Built on Filecoin & Optimism
 
 | Layer                     | Role                                          | Impact                                                 |


### PR DESCRIPTION
This PR addresses the onboarding issue discussed earlier.
## Summary

This PR addresses a developer onboarding issue encountered while setting up the project.

While the root README provides a detailed overview of the architecture and ecosystem, it does not guide contributors on where to start or how to run a working part of the repository, which contains multiple sub-projects.

## Solution

Added a "Getting Started (For Developers)" section to the root README that provides a clear and minimal entry point for contributors.

## Changes Made

- Added a developer onboarding section in the root README
- Included example commands to run the `medical-billing` module
- Clarified that dependencies should not be installed at the root level

## Why This Helps

- Improves first-time contributor experience
- Reduces confusion around repository structure
- Provides a quick way to run a working part of the project


## Notes

- This PR does not modify any module-level READMEs
- It only documents a verified working flow without making assumptions about other modules

Closes #49 

Happy to refine this further based on feedback!