### PR TITLE
[Fix]: use immutable updates for invoice item state in NewInvoice

### DIFF
--- a/zk-medical-billing-tracker/src/pages/NewInvoice.jsx
+++ b/zk-medical-billing-tracker/src/pages/NewInvoice.jsx
@@ -288,10 +288,7 @@ export default function NewInvoice() {
                 label="Name"
                 type="text"
                 onChange={(e) => {
-                  const prevElement = item;
-                  prevElement.name = e.target.value;
-                  items[i] = prevElement;
-                  setItems([...items]);
+                  setItems(items.map((it, idx) => idx === i ? { ...it, name: e.target.value } : it));
                 }}
               />
               <Input
@@ -301,11 +298,8 @@ export default function NewInvoice() {
                 label="Quantity"
                 type="number"
                 onChange={(e) => {
-                  const prevElement = item;
-                  prevElement.quantity = parseInt(e.target.value);
-                  prevElement.total = prevElement.price * prevElement.quantity;
-                  items[i] = prevElement;
-                  setItems([...items]);
+                  const qty = parseInt(e.target.value) || 0;
+                  setItems(items.map((it, idx) => idx === i ? { ...it, quantity: qty, total: it.price * qty } : it));
                 }}
               />
               <Input
@@ -315,11 +309,8 @@ export default function NewInvoice() {
                 label={`Price (${data?.currencySymbol})`}
                 type="number"
                 onChange={(e) => {
-                  const prevElement = item;
-                  prevElement.price = parseFloat(e.target.value);
-                  prevElement.total = prevElement.price * prevElement.quantity;
-                  items[i] = prevElement;
-                  setItems([...items]);
+                  const price = parseFloat(e.target.value) || 0;
+                  setItems(items.map((it, idx) => idx === i ? { ...it, price, total: price * it.quantity } : it));
                 }}
               />
               <Input


### PR DESCRIPTION
## Problem

In `zk-medical-billing-tracker/src/pages/NewInvoice.jsx`, the three `onChange` handlers for invoice line-item fields (Name, Quantity, Price) directly mutate the existing object in the `items` array before calling `setItems`:

```js
// ❌ Mutates the original item object
const prevElement = item;
prevElement.name = e.target.value;   // direct mutation
items[i] = prevElement;
setItems([...items]);
```

Because `prevElement` is just a reference to the same object in `items`, this mutates React state in place. React does not detect the mutation, so dependent components may fail to re-render and derived values (like `total`) can become stale.

## Fix

Replace the mutation pattern with immutable `.map()` updates that produce new objects:

```js
// ✅ Name
onChange={(e) => {
  setItems(items.map((it, idx) => idx === i ? { ...it, name: e.target.value } : it));
}}

// ✅ Quantity – also guards against NaN from empty input
onChange={(e) => {
  const qty = parseInt(e.target.value) || 0;
  setItems(items.map((it, idx) => idx === i ? { ...it, quantity: qty, total: it.price * qty } : it));
}}

// ✅ Price – also guards against NaN from empty input
onChange={(e) => {
  const price = parseFloat(e.target.value) || 0;
  setItems(items.map((it, idx) => idx === i ? { ...it, price, total: price * it.quantity } : it));
}}
```

This ensures React always receives a new array with new item objects, triggering proper re-renders and keeping `total` in sync with `price` and `quantity`.