### PR TITLE
[Fix]: use immutable updates for invoice item state in UpdateInvoice

### DIFF
--- a/zk-medical-billing-tracker/src/pages/UpdateInvoice.jsx
+++ b/zk-medical-billing-tracker/src/pages/UpdateInvoice.jsx
@@ -303,10 +303,7 @@ export default function UpdateInvoice() {
                   type="text"
                   value={item.name}
                   onChange={(e) => {
-                    const prevElement = item;
-                    prevElement.name = e.target.value;
-                    items[i] = prevElement;
-                    setItems([...items]);
+                    setItems(items.map((it, idx) => idx === i ? { ...it, name: e.target.value } : it));
                   }}
                 />
                 <Input
@@ -317,12 +314,8 @@ export default function UpdateInvoice() {
                   type="number"
                   value={item.quantity}
                   onChange={(e) => {
-                    const prevElement = item;
-                    prevElement.quantity = parseInt(e.target.value);
-                    prevElement.total =
-                      prevElement.price * prevElement.quantity;
-                    items[i] = prevElement;
-                    setItems([...items]);
+                    const qty = parseInt(e.target.value) || 0;
+                    setItems(items.map((it, idx) => idx === i ? { ...it, quantity: qty, total: it.price * qty } : it));
                   }}
                 />
                 <Input
@@ -333,12 +326,8 @@ export default function UpdateInvoice() {
                   type="number"
                   value={item.price}
                   onChange={(e) => {
-                    const prevElement = item;
-                    prevElement.price = parseFloat(e.target.value);
-                    prevElement.total =
-                      prevElement.price * prevElement.quantity;
-                    items[i] = prevElement;
-                    setItems([...items]);
+                    const price = parseFloat(e.target.value) || 0;
+                    setItems(items.map((it, idx) => idx === i ? { ...it, price, total: price * it.quantity } : it));
                   }}
                 />
                 <Input


### PR DESCRIPTION
## Problem

Closes #55.

The three `onChange` handlers for line-item fields (Name, Quantity, Price) in `UpdateInvoice.jsx` directly mutate the existing item object:

```js
// ❌ Mutates the original item object
const prevElement = item;
prevElement.name = e.target.value;
items[i] = prevElement;
setItems([...items]);
```

Because `prevElement` is just a reference to the same object, this mutates React state in place. Spreading `[...items]` creates a new array but the inner objects remain the same references, so React may skip re-renders and derived values (`total`) can go stale.

## Fix

All three handlers now use immutable `.map()` updates that produce new objects:

```js
// ✅ Name
onChange={(e) => {
  setItems(items.map((it, idx) => idx === i ? { ...it, name: e.target.value } : it));
}}

// ✅ Quantity (also guards against NaN from empty input)
onChange={(e) => {
  const qty = parseInt(e.target.value) || 0;
  setItems(items.map((it, idx) => idx === i ? { ...it, quantity: qty, total: it.price * qty } : it));
}}

// ✅ Price (also guards against NaN from empty input)
onChange={(e) => {
  const price = parseFloat(e.target.value) || 0;
  setItems(items.map((it, idx) => idx === i ? { ...it, price, total: price * it.quantity } : it));
}}
```

React now always receives a new array with new item objects, ensuring correct re-renders and keeping `total` in sync.

## Related

The identical bug in `NewInvoice.jsx` was fixed in #54.