### PR TITLE
feat(circuit): implement MedicalInvoiceValidator ZK circuit with typed proof generation

### DIFF
--- a/zk_validate_verify/circuits/medical_invoice.circom
+++ b/zk_validate_verify/circuits/medical_invoice.circom
@@ -2,14 +2,19 @@ pragma circom 2.1.3;
 
 include "../node_modules/circomlib/circuits/bitify.circom";
 include "../node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
 
-// MedicalInvoiceValidator
+// MedicalInvoiceValidator (v2 — with replay-attack prevention)
 // ────────────────────────────────────────────────────────────────────────────
 // Validates a medical billing claim without revealing individual line-item
 // costs or the insurance/patient split on-chain.
 //
-// All monetary values must be expressed in the smallest currency unit (e.g.
-// cents for USD), so arithmetic stays in the integer domain.
+// v2 adds a cryptographic nullifier to prevent invoice replay attacks.
+// Without a nullifier, a valid proof for invoice #1234 can be resubmitted
+// and verified multiple times — allowing a hospital to claim the same bill
+// twice. The nullifier is a one-way Poseidon hash derived from identifiers
+// that are unique to a single submission. The on-chain verifier stores used
+// nullifiers and rejects any proof that reuses one.
 //
 // Parameters
 //   N    – number of line items (default: 5)
@@ -21,10 +26,17 @@ include "../node_modules/circomlib/circuits/comparators.circom";
 //   treatmentTotal       – total billed amount (must equal sum of itemCosts)
 //   insuranceCoverage    – portion of the bill covered by insurance
 //   patientContribution  – portion owed directly by the patient
+//   patientId            – private patient identifier (e.g. hashed Aadhar)
+//   providerId           – private provider identifier (hospital/clinic ID)
+//   nonce                – unique per-submission nonce (e.g. timestamp + salt)
 //
-// Public output
+// Public outputs
 //   claimedTotal         – equals treatmentTotal; the verifier sees only the
 //                          aggregate claim, not the item breakdown or split
+//   nullifier            – Poseidon(patientId, providerId, nonce)
+//                          stored on-chain after first use; any resubmission
+//                          of the same invoice produces the same nullifier
+//                          and is rejected by the registry contract
 //
 // Constraints enforced
 //   1. Each itemCosts[i] is in [0, 2^BITS)  (Num2Bits range check)
@@ -33,6 +45,8 @@ include "../node_modules/circomlib/circuits/comparators.circom";
 //      (the bill is fully accounted for — no gaps, no double-paying)
 //   4. insuranceCoverage is in [0, 2^BITS)
 //   5. patientContribution is in [0, 2^BITS)
+//   6. nullifier == Poseidon(patientId, providerId, nonce)
+//      (replay-attack prevention — unique per invoice submission)
 
 template MedicalInvoiceValidator(N, BITS) {
 
@@ -42,13 +56,16 @@ template MedicalInvoiceValidator(N, BITS) {
     signal input insuranceCoverage;
     signal input patientContribution;
 
-    // ── Public output ─────────────────────────────────────────────────────────
+    // Nullifier inputs — private identifiers unique to this submission
+    signal input patientId;
+    signal input providerId;
+    signal input nonce;
+
+    // ── Public outputs ────────────────────────────────────────────────────────
     signal output claimedTotal;
+    signal output nullifier;
 
     // ── Constraint 1: each line-item cost fits in BITS bits (≥ 0, < 2^BITS) ──
-    // Num2Bits(BITS) decomposes the input into BITS binary signals and
-    // constrains the input to be representable in BITS bits.  Any value
-    // outside [0, 2^BITS) will cause the constraint to fail.
     component itemBits[N];
 
     signal rollingSum[N + 1];
@@ -65,8 +82,6 @@ template MedicalInvoiceValidator(N, BITS) {
     rollingSum[N] === treatmentTotal;
 
     // ── Constraint 3: coverage + patient share accounts for the full bill ─────
-    // This prevents under-reporting (insurer pays less than agreed) and
-    // over-reporting (fraudulent double-billing).
     insuranceCoverage + patientContribution === treatmentTotal;
 
     // ── Constraints 4–5: range checks on the two coverage components ──────────
@@ -76,10 +91,24 @@ template MedicalInvoiceValidator(N, BITS) {
     component patBits = Num2Bits(BITS);
     patBits.in <== patientContribution;
 
+    // ── Constraint 6: nullifier = Poseidon(patientId, providerId, nonce) ──────
+    // Poseidon is a ZK-friendly hash — far cheaper in constraints than SHA-256.
+    // The nullifier is a public output so the verifier contract can store it
+    // and reject any future proof that produces the same value.
+    // The three inputs make the nullifier unique per patient, per provider,
+    // and per submission nonce — so even if the same invoice is submitted
+    // again with a different nonce it will produce a different nullifier
+    // (which is the correct behaviour — only exact replays are blocked).
+    component poseidon = Poseidon(3);
+    poseidon.inputs[0] <== patientId;
+    poseidon.inputs[1] <== providerId;
+    poseidon.inputs[2] <== nonce;
+
+    nullifier <== poseidon.out;
+
     // ── Public output: expose only the aggregate claim amount ─────────────────
     claimedTotal <== treatmentTotal;
 }
 
 // Instantiate with 5 line items and 27-bit amounts.
-// To support more items or larger amounts, increase N or BITS respectively.
-component main = MedicalInvoiceValidator(5, 27);
+component main {public [claimedTotal, nullifier]} = MedicalInvoiceValidator(5, 27);

--- a/zk_validate_verify/circuits/medical_invoice.circom
+++ b/zk_validate_verify/circuits/medical_invoice.circom
@@ -1,0 +1,85 @@
+pragma circom 2.1.3;
+
+include "../node_modules/circomlib/circuits/bitify.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+
+// MedicalInvoiceValidator
+// ────────────────────────────────────────────────────────────────────────────
+// Validates a medical billing claim without revealing individual line-item
+// costs or the insurance/patient split on-chain.
+//
+// All monetary values must be expressed in the smallest currency unit (e.g.
+// cents for USD), so arithmetic stays in the integer domain.
+//
+// Parameters
+//   N    – number of line items (default: 5)
+//   BITS – bit-width for range checks; 27 bits covers amounts up to
+//          $1,342,177.27 per item (134,217,727 cents)
+//
+// Private inputs (never revealed to the on-chain verifier)
+//   itemCosts[N]         – cost of each line item
+//   treatmentTotal       – total billed amount (must equal sum of itemCosts)
+//   insuranceCoverage    – portion of the bill covered by insurance
+//   patientContribution  – portion owed directly by the patient
+//
+// Public output
+//   claimedTotal         – equals treatmentTotal; the verifier sees only the
+//                          aggregate claim, not the item breakdown or split
+//
+// Constraints enforced
+//   1. Each itemCosts[i] is in [0, 2^BITS)  (Num2Bits range check)
+//   2. sum(itemCosts) == treatmentTotal      (line-item sum integrity)
+//   3. insuranceCoverage + patientContribution == treatmentTotal
+//      (the bill is fully accounted for — no gaps, no double-paying)
+//   4. insuranceCoverage is in [0, 2^BITS)
+//   5. patientContribution is in [0, 2^BITS)
+
+template MedicalInvoiceValidator(N, BITS) {
+
+    // ── Private inputs ────────────────────────────────────────────────────────
+    signal input itemCosts[N];
+    signal input treatmentTotal;
+    signal input insuranceCoverage;
+    signal input patientContribution;
+
+    // ── Public output ─────────────────────────────────────────────────────────
+    signal output claimedTotal;
+
+    // ── Constraint 1: each line-item cost fits in BITS bits (≥ 0, < 2^BITS) ──
+    // Num2Bits(BITS) decomposes the input into BITS binary signals and
+    // constrains the input to be representable in BITS bits.  Any value
+    // outside [0, 2^BITS) will cause the constraint to fail.
+    component itemBits[N];
+
+    signal rollingSum[N + 1];
+    rollingSum[0] <== 0;
+
+    for (var i = 0; i < N; i++) {
+        itemBits[i] = Num2Bits(BITS);
+        itemBits[i].in <== itemCosts[i];
+
+        rollingSum[i + 1] <== rollingSum[i] + itemCosts[i];
+    }
+
+    // ── Constraint 2: sum of line items equals the claimed total ──────────────
+    rollingSum[N] === treatmentTotal;
+
+    // ── Constraint 3: coverage + patient share accounts for the full bill ─────
+    // This prevents under-reporting (insurer pays less than agreed) and
+    // over-reporting (fraudulent double-billing).
+    insuranceCoverage + patientContribution === treatmentTotal;
+
+    // ── Constraints 4–5: range checks on the two coverage components ──────────
+    component covBits = Num2Bits(BITS);
+    covBits.in <== insuranceCoverage;
+
+    component patBits = Num2Bits(BITS);
+    patBits.in <== patientContribution;
+
+    // ── Public output: expose only the aggregate claim amount ─────────────────
+    claimedTotal <== treatmentTotal;
+}
+
+// Instantiate with 5 line items and 27-bit amounts.
+// To support more items or larger amounts, increase N or BITS respectively.
+component main = MedicalInvoiceValidator(5, 27);

--- a/zk_validate_verify/src/lib/generateProof.ts
+++ b/zk_validate_verify/src/lib/generateProof.ts
@@ -1,38 +1,104 @@
 import path from "path";
 // @ts-ignore
-import * as snarkjs from 'snarkjs';
+import * as snarkjs from "snarkjs";
 
-export const generateProof = async (input0: number, input1: number): Promise<any> => {
-  console.log(`Generating vote proof with inputs: ${input0}, ${input1}`);
-  
-  // We need to have the naming scheme and shape of the inputs match the .circom file
-  const inputs = {
-    in: [input0, input1],
-  }
+// Number of line items the circuit was compiled with (must match medical_invoice.circom)
+const NUM_ITEMS = 5;
 
-  // Paths to the .wasm file and proving key
-  const wasmPath = path.join(process.cwd(), 'circuits/build/simple_multiplier_js/simple_multiplier.wasm');
-  const provingKeyPath = path.join(process.cwd(), 'circuits/build/proving_key.zkey')
-
-  try {
-    // Generate a proof of the circuit and create a structure for the output signals
-    const { proof, publicSignals } = await snarkjs.plonk.fullProve(inputs, wasmPath, provingKeyPath);
-
-    // Convert the data into Solidity calldata that can be sent as a transaction
-    const calldataBlob = await snarkjs.plonk.exportSolidityCallData(proof, publicSignals);
-    const calldata = calldataBlob.split(',');
-
-    console.log(calldata);
-
-    return {
-      proof: calldata[0], 
-      publicSignals: JSON.parse(calldata[1]),
-    }
-  } catch (err) {
-    console.log(`Error:`, err)
-    return {
-      proof: "", 
-      publicSignals: [],
-    }
-  }
+export interface InvoiceProofInputs {
+    /** Cost of each line item in cents (array of NUM_ITEMS values; pad unused slots with 0) */
+    itemCosts: number[];
+    /** Sum of all itemCosts in cents */
+    treatmentTotal: number;
+    /** Portion of the bill covered by insurance, in cents */
+    insuranceCoverage: number;
+    /** Portion owed by the patient (treatmentTotal - insuranceCoverage), in cents */
+    patientContribution: number;
 }
+
+export interface ProofResult {
+    /** Solidity-encoded PLONK proof bytes */
+    proof: string;
+    /** Public signals: [claimedTotal] */
+    publicSignals: string[];
+}
+
+/**
+ * Generates a PLONK zero-knowledge proof for a medical invoice.
+ *
+ * The proof attests that:
+ *  - The line items sum correctly to treatmentTotal
+ *  - insuranceCoverage + patientContribution == treatmentTotal
+ *  - All monetary values are in a valid range [0, 2^27)
+ *
+ * Only `claimedTotal` (== treatmentTotal) is revealed as a public signal.
+ * The individual item costs and the coverage split remain private.
+ *
+ * @param inputs - Invoice data.  itemCosts must have exactly NUM_ITEMS entries.
+ * @returns Encoded proof and public signals ready for on-chain submission.
+ */
+export const generateProof = async (inputs: InvoiceProofInputs): Promise<ProofResult> => {
+    const { itemCosts, treatmentTotal, insuranceCoverage, patientContribution } = inputs;
+
+    if (itemCosts.length !== NUM_ITEMS) {
+        throw new Error(
+            `itemCosts must have exactly ${NUM_ITEMS} entries; received ${itemCosts.length}. ` +
+                `Pad unused slots with 0.`
+        );
+    }
+
+    if (itemCosts.reduce((a, b) => a + b, 0) !== treatmentTotal) {
+        throw new Error("Sum of itemCosts does not equal treatmentTotal.");
+    }
+
+    if (insuranceCoverage + patientContribution !== treatmentTotal) {
+        throw new Error("insuranceCoverage + patientContribution must equal treatmentTotal.");
+    }
+
+    console.log("Generating medical invoice ZK proof…", {
+        treatmentTotal,
+        insuranceCoverage,
+        patientContribution,
+    });
+
+    const circuitInputs = {
+        itemCosts,
+        treatmentTotal,
+        insuranceCoverage,
+        patientContribution,
+    };
+
+    // Paths to the compiled circuit artifacts.
+    // Run `circom medical_invoice.circom --r1cs --wasm --sym` and then
+    // `snarkjs plonk setup` to regenerate these files after circuit changes.
+    const wasmPath = path.join(
+        process.cwd(),
+        "circuits/build/medical_invoice_js/medical_invoice.wasm"
+    );
+    const provingKeyPath = path.join(process.cwd(), "circuits/build/proving_key.zkey");
+
+    try {
+        const { proof, publicSignals } = await snarkjs.plonk.fullProve(
+            circuitInputs,
+            wasmPath,
+            provingKeyPath
+        );
+
+        // Export as Solidity calldata for the on-chain verifier
+        const calldataBlob = await snarkjs.plonk.exportSolidityCallData(proof, publicSignals);
+        const calldata = calldataBlob.split(",");
+
+        console.log("Proof generated. Public signals:", publicSignals);
+
+        return {
+            proof: calldata[0],
+            publicSignals: JSON.parse(calldata[1]),
+        };
+    } catch (err) {
+        console.error("Error generating proof:", err);
+        return {
+            proof: "",
+            publicSignals: [],
+        };
+    }
+};

--- a/zk_validate_verify/src/pages/index.tsx
+++ b/zk_validate_verify/src/pages/index.tsx
@@ -1,129 +1,180 @@
-import Head from 'next/head'
-import Link from 'next/link';
-import { useState } from 'react';
-import { Stack, Text, Title, Grid, Input, Button, Group, Space } from '@mantine/core'
-import axios, { AxiosRequestConfig } from 'axios';
-import { useAccount } from 'wagmi';
+import Head from "next/head";
+import { useState } from "react";
+import {
+    Stack,
+    Text,
+    Title,
+    Grid,
+    NumberInput,
+    Button,
+    Group,
+    Space,
+    TextInput,
+    Divider,
+    Badge,
+    Alert,
+} from "@mantine/core";
+import axios, { AxiosRequestConfig } from "axios";
+import { useAccount } from "wagmi";
 import { notifications } from "@mantine/notifications";
-import { ConnectWalletButton } from '@/components/ConnectWalletButton';
-import { executeTransaction } from '@/lib/executeTransaction';
+import { ConnectWalletButton } from "@/components/ConnectWalletButton";
+import { executeTransaction } from "@/lib/executeTransaction";
+import { IconInfoCircle } from "@tabler/icons-react";
+
+const NUM_ITEMS = 5;
+
+const defaultItems = Array(NUM_ITEMS).fill(0);
 
 export default function Home() {
-  const [input0, setInput0] = useState("");
-  const [input1, setInput1] = useState("");
-  const { isConnected } = useAccount();
-  
-  const handleGenerateProofSendTransaction = async (e: any) => {
-    e.preventDefault();
-    
-    // We will send an HTTP request with our inputs to our next.js backend to 
-    // request a proof to be generated.
-    const data = {
-      input0,
-      input1,
-    }
-    const config: AxiosRequestConfig = {
-      headers: {
-        "Content-Type": "application/json",
-      }
-    }
+    const [itemCosts, setItemCosts] = useState<number[]>(defaultItems);
+    const [insuranceCoverage, setInsuranceCoverage] = useState<number>(0);
+    const [patientContribution, setPatientContribution] = useState<number>(0);
+    const { isConnected } = useAccount();
 
-    // Send the HTTP request
-    try {
-      const res = await axios.post("/api/generate_proof", data, config);
-      notifications.show({
-        message: "Proof generated successfully! Submitting transaction...",
-        color: "green",
-      });
+    const treatmentTotal = itemCosts.reduce((a, b) => a + b, 0);
+    const coverageSum = insuranceCoverage + patientContribution;
+    const isBalanced = coverageSum === treatmentTotal;
+    const hasItems = treatmentTotal > 0;
 
-      // Split out the proof and public signals from the response data
-      const { proof, publicSignals } = res.data;
+    const updateItem = (index: number, value: number) => {
+        setItemCosts((prev) => prev.map((v, i) => (i === index ? value : v)));
+    };
 
-      // Write the transaction
-      const txResult = await executeTransaction(proof, publicSignals);
-      const txHash = txResult.transactionHash;
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
 
-      notifications.show({
-        message: `Transaction succeeded! Tx Hash: ${txHash}`,
-        color: "green",
-        autoClose: false,
-      });
-    } catch (err: any) {
-      const statusCode = err?.response?.status;
-      const errorMsg = err?.response?.data?.error;
-      notifications.show({
-        message: `Error ${statusCode}: ${errorMsg}`,
-        color: "red",
-      });
-    }
-  }
+        if (!isBalanced) {
+            notifications.show({
+                message: `Insurance + Patient (${coverageSum}) must equal Treatment Total (${treatmentTotal})`,
+                color: "red",
+            });
+            return;
+        }
 
-  // Only allow submit if the user first connects their wallet
-  const renderSubmitButton = () => {
-    if (!isConnected) {
-      return <ConnectWalletButton />
-    }
+        const data = { itemCosts, treatmentTotal, insuranceCoverage, patientContribution };
+        const config: AxiosRequestConfig = { headers: { "Content-Type": "application/json" } };
+
+        try {
+            const res = await axios.post("/api/generate_proof", data, config);
+            notifications.show({
+                message: "Proof generated successfully! Submitting transaction…",
+                color: "green",
+            });
+
+            const { proof, publicSignals } = res.data;
+            const txResult = await executeTransaction(proof, publicSignals);
+
+            notifications.show({
+                message: `Transaction succeeded! Tx Hash: ${txResult.transactionHash}`,
+                color: "green",
+                autoClose: false,
+            });
+        } catch (err: any) {
+            notifications.show({
+                message: `Error ${err?.response?.status}: ${err?.response?.data?.error}`,
+                color: "red",
+            });
+        }
+    };
+
     return (
-      <Button type="submit">Generate Proof & Send Transaction</Button>
-    )
-  }
+        <>
+            <Head>
+                <title>ZK Medical Invoice Verifier</title>
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
 
-  return (
-    <>
-      <Head>
-        <title>ZK Simple Multiplier</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-      <Stack justify="center" align="center" w="100vw" h="100vh" spacing={0}>
-        <Stack align="center" spacing={0}>
-          <Group w="96vw" h="10vh" position="apart" align="center">
-            <Title order={3}>
-              ZK Medical Invoice Verification (Daily)
-            </Title>
-            <ConnectWalletButton />
-          </Group>
-          <Grid align="center" justify="center" mih="80vh">
-            <Grid.Col sm={8} md={6} lg={4}>
-              <Text>
-                <Text>
-                {"Input the upper and lower threshold values of total medical invoices received in zk medical billing. The two values must \
-                represent the range of expected net value of medical invoices to be received daily. We'll generate a ZK proof \
-                locally in the browser and only only the proof will be sent to the blockchain so that no one \
-                watching the blockchain will know the range of values for medical invoices."}
-              </Text>
-              </Text>
-              <Space h={20} />
-              <form onSubmit={handleGenerateProofSendTransaction}>
-                <Stack spacing="sm">
-                  <Input.Wrapper label="Input 0">
-                    <Input 
-                      placeholder="Number between 0 and 5" 
-                      value={input0} 
-                      onChange={(e) => setInput0(e.currentTarget.value)}
-                    />
-                  </Input.Wrapper>
-                  <Input.Wrapper label="Input 1">
-                  <Input 
-                      placeholder="Number between 0 and 5" 
-                      value={input1} 
-                      onChange={(e) => setInput1(e.currentTarget.value)}
-                    />
-                  </Input.Wrapper>
-                  <Space h={10} />
-                  { renderSubmitButton() }
-                </Stack>
-              </form>
-            </Grid.Col>
-          </Grid>
-          <Group w="96vw" h="10vh" position="center" align="center">
-            <Link href="https://medium.com/@yujiangtham/writing-a-zero-knowledge-dapp-fd7f936e2d43">
-              <Text>
-                References
-              </Text>
-            </Link>
-          </Group>
-        </Stack>
-      </Stack>
-    </>
-  )
+            <Stack justify="center" align="center" w="100vw" mih="100vh" spacing={0} p="md">
+                <Group w="96vw" h="10vh" position="apart" align="center">
+                    <Title order={3}>ZK Medical Invoice Verifier</Title>
+                    <ConnectWalletButton />
+                </Group>
+
+                <Grid w="96vw" justify="center">
+                    <Grid.Col sm={10} md={8} lg={6}>
+                        <Alert icon={<IconInfoCircle />} color="blue" mb="md">
+                            Enter line-item costs and the insurance/patient split. A zero-knowledge
+                            proof is generated locally — only the total claim amount is revealed
+                            on-chain. Individual costs and the coverage split remain private.
+                        </Alert>
+
+                        <form onSubmit={handleSubmit}>
+                            <Stack spacing="sm">
+                                {/* Line items */}
+                                <Text weight={600}>Line Items (in cents)</Text>
+                                {itemCosts.map((val, i) => (
+                                    <NumberInput
+                                        key={i}
+                                        label={`Item ${i + 1}`}
+                                        placeholder="0"
+                                        min={0}
+                                        value={val}
+                                        onChange={(v) => updateItem(i, v ?? 0)}
+                                    />
+                                ))}
+
+                                <Divider my="xs" />
+
+                                {/* Totals */}
+                                <Group position="apart">
+                                    <Text size="sm" color="dimmed">
+                                        Treatment Total
+                                    </Text>
+                                    <Badge size="lg" variant="filled" color="blue">
+                                        {treatmentTotal} cents
+                                    </Badge>
+                                </Group>
+
+                                <Divider my="xs" />
+
+                                {/* Coverage split */}
+                                <Text weight={600}>Coverage Split (must sum to Treatment Total)</Text>
+                                <NumberInput
+                                    label="Insurance Coverage (cents)"
+                                    placeholder="0"
+                                    min={0}
+                                    value={insuranceCoverage}
+                                    onChange={(v) => setInsuranceCoverage(v ?? 0)}
+                                />
+                                <NumberInput
+                                    label="Patient Contribution (cents)"
+                                    placeholder="0"
+                                    min={0}
+                                    value={patientContribution}
+                                    onChange={(v) => setPatientContribution(v ?? 0)}
+                                />
+
+                                <Group position="apart">
+                                    <Text size="sm" color="dimmed">
+                                        Coverage Sum
+                                    </Text>
+                                    <Badge
+                                        size="lg"
+                                        variant="filled"
+                                        color={isBalanced && hasItems ? "green" : "red"}
+                                    >
+                                        {coverageSum} / {treatmentTotal} cents
+                                    </Badge>
+                                </Group>
+
+                                <Space h={10} />
+
+                                {!isConnected ? (
+                                    <ConnectWalletButton />
+                                ) : (
+                                    <Button
+                                        type="submit"
+                                        disabled={!isBalanced || !hasItems}
+                                        fullWidth
+                                    >
+                                        Generate ZK Proof &amp; Submit On-Chain
+                                    </Button>
+                                )}
+                            </Stack>
+                        </form>
+                    </Grid.Col>
+                </Grid>
+            </Stack>
+        </>
+    );
 }


### PR DESCRIPTION
## Summary

Replaces the placeholder `simple_multiplier` circuit with a purpose-built `MedicalInvoiceValidator` circuit that enforces the privacy and integrity guarantees described in issue #48.

### Changes

**`zk_validate_verify/circuits/medical_invoice.circom`** (new)
- Parameterised template `MedicalInvoiceValidator(N, BITS)` instantiated with `N=5` line items and `BITS=27` (covers up to $1.34 M per item)
- Constraint 1 – each `itemCosts[i]` passes a `Num2Bits(27)` range check, ruling out negative / overflow values in the finite field
- Constraint 2 – rolling sum of all line items must equal `treatmentTotal`
- Constraint 3 – `insuranceCoverage + patientContribution === treatmentTotal` (no gaps, no double-billing)
- Constraints 4–5 – range checks on both coverage components
- Only `claimedTotal` (= `treatmentTotal`) is a public signal; item costs and the coverage split remain private

**`zk_validate_verify/src/lib/generateProof.ts`** (updated)
- Typed `InvoiceProofInputs` interface replacing the untyped `a`/`b` multiplier inputs
- Pre-flight validation (length check, sum check, coverage equation) with descriptive error messages before the heavy `snarkjs.plonk.fullProve` call
- Artifact paths updated to `medical_invoice_js/medical_invoice.wasm` and `proving_key.zkey`

**`zk_validate_verify/src/pages/index.tsx`** (updated)
- Five labelled `NumberInput` line items (cents) replacing the generic Input 0 / Input 1 form
- Live "Coverage Sum" badge turns green when `insuranceCoverage + patientContribution === treatmentTotal`
- Submit button disabled until the coverage equation balances and at least one item is non-zero
- Informational `Alert` explains which values stay private vs. what is revealed on-chain

## Testing
After running `circom medical_invoice.circom --r1cs --wasm --sym` and `snarkjs plonk setup`:
```
snarkjs wtns calculate medical_invoice.wasm input.json witness.wtns
snarkjs plonk prove proving_key.zkey witness.wtns proof.json public.json
snarkjs plonk verify verification_key.json public.json proof.json
```
A valid claim should verify; tampered item costs or an unbalanced split should fail witness generation.