### PR TITLE
[Fix]: use invoice.uid as row key and avoid mutating invoices array in Invoices.jsx

### DIFF
--- a/zk-medical-billing-tracker/src/pages/Invoices.jsx
+++ b/zk-medical-billing-tracker/src/pages/Invoices.jsx
@@ -95,7 +95,11 @@ export default function Invoices() {
     return invoices.slice(start, end);
   }, [page, invoices]);
   useEffect(() => {
-    setInvoices(data?.invoices.reverse() || []);
+    // Spread into a new array before reversing so the original array held by
+    // the useData hook is not mutated. Calling .reverse() on the shared
+    // reference would flip the order on the next render, causing invoices to
+    // alternate direction each time the component updates.
+    setInvoices(data?.invoices ? [...data.invoices].reverse() : []);
   }, [data]);
   const refreshData = () =>
     setRefresh((prev) => {
@@ -198,7 +202,10 @@ export default function Invoices() {
         </TableHeader>
         <TableBody items={items}>
           {(item) => (
-            <TableRow key={`${Math.random()}`}>
+            // Use invoice.uid as the key so React can identify each row
+            // across renders. Math.random() would cause every row to unmount
+            // and remount on every update, destroying DOM state unnecessarily.
+            <TableRow key={item.uid}>
               {(columnKey) => (
                 <TableCell>
                   {renderCell(item, columnKey, data.currencySymbol || "₹")}


### PR DESCRIPTION
Fixes #60

## Summary

Two React bugs in `zk-medical-billing-tracker/src/pages/Invoices.jsx`.

---

### Bug 1 — `Math.random()` row key causes full table remount on every render

```jsx
// Before
<TableRow key={`${Math.random()}`}>

// After
<TableRow key={item.uid}>
```

React uses keys to decide which elements changed between renders. A random key tells React that every row is brand new on every render, so it tears down and rebuilds all 13 visible rows on each state change. Using the stable `invoice.uid` lets React reconcile correctly, preserving DOM state and eliminating unnecessary remounts.

---

### Bug 2 — `.reverse()` mutates the shared array from `useData`

```js
// Before
setInvoices(data?.invoices.reverse() || []);

// After
setInvoices(data?.invoices ? [...data.invoices].reverse() : []);
```

`Array.prototype.reverse()` mutates in place. Since `data.invoices` is a reference held by the `useData` hook, calling `.reverse()` on it permanently flips the underlying array. The next render reverses it again, causing invoices to oscillate in order on each update. Copying into a new array first with spread ensures the hook's data is never modified.