### PR TITLE
[Fix]: correct item.value typo to item.quantity and guard empty items list in ViewInvoice

### DIFF
--- a/zk-medical-billing-tracker/src/pages/ViewInvoice.jsx
+++ b/zk-medical-billing-tracker/src/pages/ViewInvoice.jsx
@@ -225,9 +225,9 @@ export default function ViewInvoice() {
         <Divider className="mt-1 mb-4" />
 
         <div className="flex flex-col gap-6">
-          {items.length &&
+          {items.length > 0 &&
             items.map((item, i) => (
-              <div className="flex gap-8 items-center w-full" key={i}>
+              <div className="flex gap-8 items-center w-full" key={item.name + i}>
                 <span className="min-w-fit bg-[#27272a] flex items-center px-4 rounded-full aspect-square">
                   {i + 1}
                 </span>
@@ -244,6 +244,7 @@ export default function ViewInvoice() {
                   className="w-full rounded-xl"
                   variant="faded"
                   isRequired
+                  readOnly
                   label="Quantity"
                   type="number"
                   value={item.quantity}
@@ -252,6 +253,7 @@ export default function ViewInvoice() {
                   className="w-full rounded-xl"
                   variant="faded"
                   isRequired
+                  readOnly
                   label={`Price (${data?.currencySymbol})`}
                   type="number"
                   value={item.price}
@@ -260,9 +262,9 @@ export default function ViewInvoice() {
                   className="w-full rounded-xl"
                   variant="faded"
                   isRequired
-                  readOnly={true}
+                  readOnly
                   label={`Total (${data?.currencySymbol})`}
-                  value={item.total || item.price * item.value}
+                  value={item.total || item.price * item.quantity}
                 />
               </div>
             ))}


### PR DESCRIPTION
## Summary

Three bugs in `zk-medical-billing-tracker/src/pages/ViewInvoice.jsx`.

---

### Bug 1 — `item.value` typo produces NaN item totals

```jsx
// Before
value={item.total || item.price * item.value}

// After
value={item.total || item.price * item.quantity}
```

`item.value` does not exist on the item object — the field is `item.quantity`. The fallback expression `item.price * item.value` always evaluates to `NaN`, so any item whose `total` field is falsy (0 or missing) shows nothing in the Total column.

---

### Bug 2 — `items.length &&` renders `0` in the DOM when array is empty

```jsx
// Before — renders the number 0 visibly when items is []
{items.length && items.map(...)}

// After — renders nothing
{items.length > 0 && items.map(...)}
```

When `items` is an empty array, `items.length` is `0`. React renders falsy numbers (except `0`) as nothing, but `0` itself is rendered as the text node `"0"` in the DOM. Using `> 0` makes the condition a boolean and prevents the stray character.

---

### Bug 3 — Quantity and Price inputs missing `readOnly` in a view-only page

The Quantity and Price `<Input>` components in the items list did not have `readOnly`, making them appear editable even though ViewInvoice is a read-only page. Added `readOnly` to both, consistent with the Name and Total fields.