### PR TITLE
fix: use _userId instead of totalUsers in PatientHistory

### DIFF
--- a/MedETH/foundry/src/UserSide.sol
+++ b/MedETH/foundry/src/UserSide.sol
@@ -127,7 +127,7 @@ contract UserSide is Ownable {
         uint256 _userExp
     ) public {
         PatientHistory memory pt1 = PatientHistory(
-            totalUsers,
+            _userId,
             _isHandicap,
             _isBp,
             _isDiabetes,


### PR DESCRIPTION
## Summary

This PR fixes an incorrect `userId` assignment inside the `PatientHistory` struct in `takeUserHistory`.
closes #63 

## Problem

Previously, the struct was initialized using the global counter `totalUsers`:

```solidity id="6vvmdn"
PatientHistory memory pt1 = PatientHistory(
    totalUsers,
    ...
);
```

This caused the stored `userId` field to reference the next user registration counter instead of the actual patient whose history was being recorded.

Although the mapping key remained correct, any frontend or contract logic reading `patientHistory.userId` would receive incorrect data.

## Fix

Replaced `totalUsers` with the `_userId` parameter:

```solidity id="m3n12h"
PatientHistory memory pt1 = PatientHistory(
    _userId,
    ...
);
```

## Impact

* Ensures consistency between mapping keys and struct data
* Prevents incorrect patient identification
* Avoids misleading frontend/API responses
