### PR TITLE
fix: add access control to uploadMedicalReprt to prevent forged records

### DIFF
--- a/MedETH/foundry/src/DoctorSide.sol
+++ b/MedETH/foundry/src/DoctorSide.sol
@@ -81,6 +81,15 @@ contract DoctorSide is UserSide {
         address _doctorWalletAddress,
         string memory _ipfsHash
     ) public {
+        require(
+            msg.sender == _doctorWalletAddress,
+            "Only the assigned doctor can upload a report"
+        );
+        uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
+        require(
+            userIdtoUser[doctorId].userRole == 2 && userIdtoUser[doctorId].isVerified,
+            "Only verified doctors can upload reports"
+        );
         PatientReport memory r1 = PatientReport(
             totalDocuments,
             _reportName,
@@ -90,7 +99,6 @@ contract DoctorSide is UserSide {
         );
         ReportIdtoPatintReport[totalDocuments] = r1;
         uint256 patId = userWalletAddresstoUserId[_patientWalletAdress];
-        uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
         patientIdtoReport[patId].push(r1);
         doctortIdtoReport[doctorId].push(r1);
         totalDocuments++;


### PR DESCRIPTION
## PR Description

### Summary

This PR fixes a critical access control vulnerability in `uploadMedicalReprt` inside `DoctorSide.sol`.

Previously, the function allowed any arbitrary address to upload medical reports for any patient wallet address without validating the caller’s authorization.

### Changes Made

* Added authorization validation before storing medical reports
* Restricted report uploads to authorized/registered doctors only
* Prevented unauthorized users from forging or poisoning patient medical records

### Security Impact

This vulnerability allowed attackers to:

* Upload fake medical reports
* Manipulate patient history
* Impersonate doctors
* Corrupt the integrity of on-chain healthcare data

The added access control ensures only valid doctors can upload reports.

### Related Issue

Closes #65
