### PR TITLE
fix: secure reportUser with auth, self-report prevention, and duplicate-report checks

### DIFF
--- a/MedETH/foundry/src/UserSide.sol
+++ b/MedETH/foundry/src/UserSide.sol
@@ -46,6 +46,7 @@ contract UserSide is Ownable {
     mapping(uint256 => PatientHistory) public userIdtoPatientHistory;
     mapping(uint256 => string[]) public userIdtoPrevMedicalHistory;
     mapping(string => uint256) public userEmailtoUserId;
+    mapping(uint256 => mapping(uint256 => bool)) public hasReported;
 
     // Constructor
     constructor(address _mediToken) Ownable(msg.sender) {
@@ -156,6 +157,12 @@ contract UserSide is Ownable {
     }
 
     function reportUser(uint256 _userId) public {
+        uint256 reporterId = userWalletAddresstoUserId[msg.sender];
+        require(reporterId != 0, "Only registered users can report");
+        require(reporterId != _userId, "Cannot report yourself");
+        require(!hasReported[reporterId][_userId], "You have already reported this user");
+
+        hasReported[reporterId][_userId] = true;
         userIdtoReportUser[_userId]++;
         if (userIdtoReportUser[_userId] > 100) {
             userIdtoBlacklist[_userId] = true;


### PR DESCRIPTION


## Problem

`reportUser` in `UserSide.sol` had no authentication or duplicate-report protection. Any address — including unregistered users — could repeatedly call the function to blacklist any user after just 101 calls.

This allowed attackers to instantly and permanently blacklist doctors or patients, effectively causing a denial of service against legitimate users.

## Fix
Closes #71

Added validation checks before incrementing the report count:

1. Caller must be a registered user
2. Users cannot report themselves
3. Each user can report another user only once

Also introduced a `hasReported` mapping to track reporter-target relationships and prevent duplicate submissions.

## Changes

* Hardened `reportUser` with authorization and validation checks
* Added self-report prevention
* Added duplicate-report protection
* Added `hasReported` mapping:

  ```solidity
  mapping(uint256 => mapping(uint256 => bool)) public hasReported;
  ```

## Security Impact

This prevents malicious actors from mass-reporting and arbitrarily blacklisting legitimate users through repeated calls.



