### PR TITLE
ci: add GitHub Actions workflow for lint, build, and forge tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ─────────────────────────────────────────────
+  # Job 1: Lint & Build — zk-medical-billing-tracker
+  # ─────────────────────────────────────────────
+  tracker-lint-build:
+    name: Tracker — Lint & Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: zk-medical-billing-tracker
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: zk-medical-billing-tracker/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  # ─────────────────────────────────────────────
+  # Job 2: Lint & Build — zk_validate_verify (Next.js)
+  # ─────────────────────────────────────────────
+  zk-validate-lint-build:
+    name: ZK Validate — Lint & Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: zk_validate_verify
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: zk_validate_verify/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+  # ─────────────────────────────────────────────
+  # Job 3: Forge Build — MedETH contracts
+  # ─────────────────────────────────────────────
+  medeth-forge-build:
+    name: MedETH — Forge Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: MedETH/foundry
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install Forge dependencies
+        run: forge install
+
+      - name: Build contracts
+        run: forge build
+
+  # ─────────────────────────────────────────────
+  # Job 4: Forge Build & Test — Medi_Token
+  # ─────────────────────────────────────────────
+  meditoken-forge-test:
+    name: Medi Token — Forge Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Medi_Token
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install Forge dependencies
+        run: forge install
+
+      - name: Build contracts
+        run: forge build
+
+      - name: Run tests
+        run: forge test -vvv


### PR DESCRIPTION
## Summary

Closes #78

## Problem

While exploring the repository as part of DMP 2026 preparation, I noticed 
that the repository had no `.github/workflows/` directory at all — meaning 
every single pull request that has ever been merged into `main` was merged 
without any automated validation whatsoever.

For a Web3 healthcare project like ZKMedical-Billing, where smart contracts 
handle sensitive patient billing data and medical records, this is a 
significant risk. A broken Solidity contract, a failing React build, or a 
lint error can silently enter the codebase with no warning to the maintainer 
or the contributor who opened the PR.

With 20+ open pull requests and multiple active contributors, this gap becomes 
even more critical — there is no safety net.

## What I Did

I analyzed each active module in the repository to understand what tooling 
was already in place, what scripts existed, and what could realistically be 
automated. Based on that analysis I created `.github/workflows/ci.yml` — a 
GitHub Actions workflow that runs automatically on every push and pull request 
targeting `main`.

The workflow has 4 independent jobs, one per active module:

**Job 1 — `tracker-lint-build` (zk-medical-billing-tracker)**
- Installs Node.js 20 and npm dependencies
- Runs `npm run lint` to catch code quality issues
- Runs `npm run build` to verify the React/Ionic app compiles cleanly

**Job 2 — `zk-validate-lint-build` (zk_validate_verify)**
- Installs Node.js 20 and npm dependencies  
- Runs `npm run build` to verify the Next.js ZK verification app compiles

**Job 3 — `medeth-forge-build` (MedETH/foundry)**
- Installs Foundry via the official `foundry-rs/foundry-toolchain` action
- Runs `forge install` and `forge build` to verify core smart contracts compile
- Note: `forge test` is intentionally excluded here since `MedETH/foundry/test/` 
  does not exist yet — a follow-up PR will add the Foundry test suite

**Job 4 — `meditoken-forge-test` (Medi_Token)**
- Installs Foundry and runs `forge install` + `forge build` + `forge test -vvv`
- This is the only module with an existing `test/` directory so full test 
  execution is included here

## Key Technical Decisions

**`submodules: recursive` on every checkout step** — this was the most 
important detail to get right. The Foundry projects in this repo depend on 
`forge-std` and `openzeppelin-contracts` as git submodules. Without 
`submodules: recursive`, `forge build` fails immediately because the 
libraries are missing. Every job that touches Foundry includes this.

**`zk-medical-invoice-suite` is skipped** — after checking the directory, 
`react-webapp/` is completely empty and has no `package.json`. Including it 
would cause the CI job to fail for the wrong reasons.

**Node.js 20** — chosen as the latest LTS version, compatible with both 
Vite 4 (used in the tracker) and Next.js (used in zk_validate_verify).

**`forge test -vvv`** — the `-vvv` flag provides verbose output, making it 
much easier to debug test failures directly in the GitHub Actions log.

## Impact

With this workflow in place:
- Every future PR gets automatic lint and build checks on the React frontends
- Every future PR gets Solidity compilation verified for both Foundry modules
- `Medi_Token` contract changes are validated against the existing test suite
- Contributors get immediate feedback if their changes break anything
- Maintainers can merge with confidence

This also sets the foundation for expanding CI coverage as the project grows — 
for example, once the MedETH test suite is added (planned follow-up PR), 
`forge test` can be enabled for that job with a one-line change.

## Changes Made

- Added `.github/workflows/ci.yml` (new file, 126 lines)