### PR TITLE
fix: apply duplicate wallet and email check to all user roles in createUser

### DIFF
--- a/MedETH/foundry/src/UserSide.sol
+++ b/MedETH/foundry/src/UserSide.sol
@@ -70,6 +70,11 @@ contract UserSide is Ownable {
             i_mediToken.balanceOf(msg.sender) >= 1,
             "You need to hold atleast 1 MediTokens to register"
         );
+        require(
+            userWalletAddresstoUserId[msg.sender] == 0 &&
+                userEmailtoUserId[_userEmail] == 0,
+            "User with this wallet address or email already exists"
+        );
         if (_userRole == 3) {
             User memory u1 = User(
                 totalUsers,
@@ -87,11 +92,6 @@ contract UserSide is Ownable {
             );
             userIdtoUser[totalUsers] = u1;
             takeUserHistory(totalUsers, false, false, false, 0);
-            require(
-                userWalletAddresstoUserId[u1.userWalletAddress] == 0 &&
-                    userEmailtoUserId[u1.userEmail] == 0,
-                "User with this wallet address or email already exists"
-            );
             userIdtoUser[totalUsers].isVerified = true;
             userWalletAddresstoUserId[u1.userWalletAddress] = u1.userId;
             userEmailtoUserId[u1.userEmail] = u1.userId;


### PR DESCRIPTION
## Summary

Closes #80

## Problem

While going through `MedETH/foundry/src/UserSide.sol` as part of my DMP 2026 codebase exploration, I noticed a subtle but serious data integrity bug in the `createUser` function. The function is supposed to prevent any user from registering more than once with the same wallet address or email. However the `require` check that enforces this was sitting inside the `if (_userRole == 3)` block — which only covers the Patient role. The `else` block handling Doctors and all other roles had no such protection at all.

This meant that a Doctor could call `createUser` repeatedly with the same wallet address and email, and the contract would happily stage a new `User` entry each time, incrementing `totalUsers` on every call. The corruption doesn't stop there — when the owner later calls `approveUser`, only the first duplicate registration succeeds. Every subsequent duplicate permanently fails at the check inside `approveUser` but cannot be cleaned up or reassigned, leaving ghost entries in the `userIdtoUser` mapping and wasting sequential IDs forever.

## What I Changed

The fix is minimal and surgical — I moved the duplicate check out of the `if (_userRole == 3)` block and placed it globally right after the MediToken balance check, before the if/else split. This way it applies to every role without any special casing. I also updated the check to use `msg.sender` directly instead of `u1.userWalletAddress` (which is just `msg.sender` anyway) and `_userEmail` directly from the function parameter, making the intent clearer and slightly more gas efficient since we avoid building the struct before validation.

**Before:**
```solidity
if (_userRole == 3) {
    User memory u1 = User(...);
    require(
        userWalletAddresstoUserId[u1.userWalletAddress] == 0 &&
            userEmailtoUserId[u1.userEmail] == 0,
        "User with this wallet address or email already exists"
    );
    // rest of patient logic
} else {
    // Doctor role — no duplicate check at all ❌
}
```

**After:**
```solidity
require(
    i_mediToken.balanceOf(msg.sender) >= 1,
    "You need to hold atleast 1 MediTokens to register"
);
require(
    userWalletAddresstoUserId[msg.sender] == 0 &&
        userEmailtoUserId[_userEmail] == 0,
    "User with this wallet address or email already exists"
);
if (_userRole == 3) {
    // Patient logic — no redundant require needed anymore ✅
} else {
    // Doctor logic — now protected by the global check above ✅
}
```

## Impact

With this fix, no user of any role can register more than once with the same wallet address or email. The `userIdtoUser` mapping stays clean, sequential IDs are never wasted on ghost entries, and `approveUser` will never encounter a permanently unapprovable staged registration. The error message is kept identical to what already existed in the codebase so behaviour is consistent and predictable for anyone integrating with this contract.

## Changes Made

- Modified `MedETH/foundry/src/UserSide.sol` — moved and updated the duplicate registration `require` check in `createUser` (net change: 5 lines added, 5 lines removed)