### PR TITLE
test: add Foundry test suite for UserSide and DoctorSide contracts

### DIFF
--- a/MedETH/foundry/foundry.toml
+++ b/MedETH/foundry/foundry.toml
@@ -2,6 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-remappings = ["openzeppelin=lib/openzeppelin-contracts"]
+remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/MedETH/foundry/test/DoctorSide.t.sol
+++ b/MedETH/foundry/test/DoctorSide.t.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {DoctorSide} from "../src/DoctorSide.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockMediToken is ERC20 {
+    constructor() ERC20("MediToken", "MEDT") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract DoctorSideTest is Test {
+    DoctorSide public doctorSide;
+    MockMediToken public mediToken;
+
+    address public owner = address(1);
+    address public doctor = address(2);
+    address public patient = address(3);
+
+    function setUp() public {
+        vm.startPrank(owner);
+        mediToken = new MockMediToken();
+        // Owner needs at least 1 token to call createUser inside DoctorSide constructor
+        mediToken.mint(owner, 100);
+        doctorSide = new DoctorSide(address(mediToken));
+        vm.stopPrank();
+    }
+
+    // ─────────────────────────────────────────────
+    // Constructor — System Admin setup
+    // ─────────────────────────────────────────────
+
+    function test_constructor_systemAdminCreatedAndApproved() public view {
+        uint256 adminId = doctorSide.userWalletAddresstoUserId(owner);
+        assertEq(adminId, 1);
+        (,,,,,,,,,, , bool isVerified) = doctorSide.userIdtoUser(1);
+        assertTrue(isVerified);
+    }
+
+    function test_constructor_totalUsersIsTwo() public view {
+        // starts at 1, admin creation increments to 2
+        assertEq(doctorSide.totalUsers(), 2);
+    }
+
+    // ─────────────────────────────────────────────
+    // openTimeslots
+    // ─────────────────────────────────────────────
+
+    function _registerAndApproveDoctor() internal {
+        mediToken.mint(doctor, 100);
+        vm.prank(doctor);
+        doctorSide.createUser(
+            "Dr. Smith", "1111 2222 3333", "DOC001", 40,
+            "drsmith@example.com", "Cardiology", "ipfs://img", "ipfs://deg", 2
+        );
+        uint256 doctorId = doctorSide.userWalletAddresstoUserId(doctor);
+        vm.prank(owner);
+        doctorSide.approveUser(doctorId);
+    }
+
+    function _registerPatient() internal {
+        mediToken.mint(patient, 100);
+        vm.prank(patient);
+        doctorSide.createUser(
+            "Patient Joe", "4444 5555 6666", "N/A", 30,
+            "joe@example.com", "N/A", "ipfs://img", "ipfs://deg", 3
+        );
+    }
+
+    function test_openTimeslots_revertsForUnverifiedUser() public {
+        mediToken.mint(doctor, 100);
+        vm.prank(doctor);
+        doctorSide.createUser(
+            "Dr. Smith", "1111 2222 3333", "DOC001", 40,
+            "drsmith@example.com", "Cardiology", "ipfs://img", "ipfs://deg", 2
+        );
+        vm.prank(doctor);
+        vm.expectRevert("Only verified doctor can call this function");
+        doctorSide.openTimeslots("2025-01-01", "09:00", "10:00");
+    }
+
+    function test_openTimeslots_revertsForPatientRole() public {
+        _registerPatient();
+        vm.prank(patient);
+        vm.expectRevert("Only verified doctor can call this function");
+        doctorSide.openTimeslots("2025-01-01", "09:00", "10:00");
+    }
+
+    function test_openTimeslots_succedsForVerifiedDoctor() public {
+        _registerAndApproveDoctor();
+        vm.prank(doctor);
+        doctorSide.openTimeslots("2025-01-01", "09:00", "10:00");
+        uint256 doctorId = doctorSide.userWalletAddresstoUserId(doctor);
+        uint256 slotCount = doctorSide.getMapping3length(doctorId, "2025-01-01");
+        assertEq(slotCount, 1);
+    }
+
+    function test_openTimeslots_totalSlotsIncrements() public {
+        _registerAndApproveDoctor();
+        vm.prank(doctor);
+        doctorSide.openTimeslots("2025-01-01", "09:00", "10:00");
+        assertEq(doctorSide.totalSlots(), 2);
+    }
+
+    // ─────────────────────────────────────────────
+    // bookAppointment
+    // ─────────────────────────────────────────────
+
+    function test_bookAppointment_revertsIfPatientHasInsufficientTokens() public {
+        _registerAndApproveDoctor();
+        mediToken.mint(patient, 4); // needs 5
+        vm.prank(patient);
+        doctorSide.createUser(
+            "Patient Joe", "4444 5555 6666", "N/A", 30,
+            "joe@example.com", "N/A", "ipfs://img", "ipfs://deg", 3
+        );
+        vm.prank(patient);
+        vm.expectRevert("You need to hold atleast 5 MediTokens to book an appointment");
+        doctorSide.bookAppointment(
+            "2025-01-01", "09:00", "10:00", "Checkup", "", doctor, 1
+        );
+    }
+
+    function test_bookAppointment_revertsIfPatientNotRegistered() public {
+        _registerAndApproveDoctor();
+        mediToken.mint(patient, 100);
+        vm.prank(patient);
+        vm.expectRevert("Patient wallet address and wallet address must be both registered into the system");
+        doctorSide.bookAppointment(
+            "2025-01-01", "09:00", "10:00", "Checkup", "", doctor, 1
+        );
+    }
+
+    function test_bookAppointment_succeedsWithValidSetup() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        vm.prank(patient);
+        doctorSide.bookAppointment(
+            "2025-01-01", "09:00", "10:00", "Checkup", "", doctor, 1
+        );
+        assertEq(doctorSide.totalAppointments(), 2);
+    }
+
+    function test_bookAppointment_revertsIfPatientBlacklisted() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        uint256 patientId = doctorSide.userWalletAddresstoUserId(patient);
+        vm.prank(owner);
+        doctorSide.disApproveUser(patientId);
+        vm.prank(patient);
+        vm.expectRevert("Either patient or doctor are blacklisted");
+        doctorSide.bookAppointment(
+            "2025-01-01", "09:00", "10:00", "Checkup", "", doctor, 1
+        );
+    }
+
+    // ─────────────────────────────────────────────
+    // bookAppointmentEmergency
+    // ─────────────────────────────────────────────
+
+    function test_bookAppointmentEmergency_revertsIfInsufficientTokens() public {
+        _registerAndApproveDoctor();
+        mediToken.mint(patient, 9); // needs 10
+        vm.prank(patient);
+        doctorSide.createUser(
+            "Patient Joe", "4444 5555 6666", "N/A", 30,
+            "joe@example.com", "N/A", "ipfs://img", "ipfs://deg", 3
+        );
+        vm.prank(patient);
+        vm.expectRevert("You need to hold atleast 10 MediTokens to book an emergency appointment");
+        doctorSide.bookAppointmentEmergency(
+            "2025-01-01", "09:00", "10:00", "Emergency", "", doctor, 1
+        );
+    }
+
+    function test_bookAppointmentEmergency_succeedsWithSufficientTokens() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        vm.prank(patient);
+        doctorSide.bookAppointmentEmergency(
+            "2025-01-01", "09:00", "10:00", "Emergency", "", doctor, 1
+        );
+        assertEq(doctorSide.totalAppointments(), 2);
+    }
+
+    // ─────────────────────────────────────────────
+    // approveAppointment
+    // ─────────────────────────────────────────────
+
+    function test_approveAppointment_setsIsApprovedTrue() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        vm.prank(patient);
+        doctorSide.bookAppointment(
+            "2025-01-01", "09:00", "10:00", "Checkup", "", doctor, 1
+        );
+        vm.prank(doctor);
+        doctorSide.approveAppointment(1);
+        (,,,,,,,,bool isApproved,,) = doctorSide.appointmentIdtoAppointment(1);
+        assertTrue(isApproved);
+    }
+
+    function test_approveAppointment_revertsForWrongDoctor() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        vm.prank(patient);
+        doctorSide.bookAppointment(
+            "2025-01-01", "09:00", "10:00", "Checkup", "", doctor, 1
+        );
+        vm.prank(patient);
+        vm.expectRevert("Invalid doctor to approve the appointment");
+        doctorSide.approveAppointment(1);
+    }
+
+    // ─────────────────────────────────────────────
+    // uploadMedicalReport
+    // ─────────────────────────────────────────────
+
+    function test_uploadMedicalReport_incrementsTotalDocuments() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        doctorSide.uploadMedicalReprt(
+            "Blood Test", patient, doctor, "ipfs://report1"
+        );
+        assertEq(doctorSide.totalDocuments(), 2);
+    }
+
+    function test_uploadMedicalReport_appearsInPatientReports() public {
+        _registerAndApproveDoctor();
+        _registerPatient();
+        doctorSide.uploadMedicalReprt(
+            "Blood Test", patient, doctor, "ipfs://report1"
+        );
+        uint256 patientId = doctorSide.userWalletAddresstoUserId(patient);
+        assertEq(doctorSide.getMapping4length(patientId), 1);
+    }
+}

--- a/MedETH/foundry/test/UserSide.t.sol
+++ b/MedETH/foundry/test/UserSide.t.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {UserSide} from "../src/UserSide.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// Minimal mock MediToken for testing
+contract MockMediToken is ERC20 {
+    constructor() ERC20("MediToken", "MEDT") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract UserSideTest is Test {
+    UserSide public userSide;
+    MockMediToken public mediToken;
+
+    address public owner = address(1);
+    address public alice = address(2);
+    address public bob = address(3);
+
+    function setUp() public {
+        vm.startPrank(owner);
+        mediToken = new MockMediToken();
+        userSide = new UserSide(address(mediToken));
+        vm.stopPrank();
+    }
+
+    // ─────────────────────────────────────────────
+    // createUser — token gate
+    // ─────────────────────────────────────────────
+
+    function test_createUser_revertsIfNoMediTokenBalance() public {
+        vm.prank(alice);
+        vm.expectRevert("You need to hold atleast 1 MediTokens to register");
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+    }
+
+    function test_createUser_patientRegistersSuccessfully() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        uint256 userId = userSide.userWalletAddresstoUserId(alice);
+        assertEq(userId, 1);
+    }
+
+    function test_createUser_totalUsersIncrements() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        assertEq(userSide.totalUsers(), 2);
+    }
+
+    function test_createUser_emailMappingSetForPatient() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        uint256 userId = userSide.userEmailtoUserId("alice@example.com");
+        assertEq(userId, 1);
+    }
+
+    function test_createUser_patientIsVerifiedImmediately() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        uint256 userId = userSide.userWalletAddresstoUserId(alice);
+        (,,,,,,,,,, , bool isVerified) = userSide.userIdtoUser(userId);
+        assertTrue(isVerified);
+    }
+
+    function test_createUser_nonPatientRoleRegisters() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Dr. Alice", "1234 5678 9012", "LIC001", 35,
+            "dr.alice@example.com", "Cardiology", "ipfs://img", "ipfs://deg", 2
+        );
+        // Doctor is not verified until approveUser is called
+        // totalUsers should still increment
+        assertEq(userSide.totalUsers(), 2);
+    }
+
+    // ─────────────────────────────────────────────
+    // Duplicate wallet / email check (PR 2 fix)
+    // ─────────────────────────────────────────────
+
+    function test_createUser_revertsOnDuplicateWalletForPatient() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        vm.prank(alice);
+        vm.expectRevert("User with this wallet address or email already exists");
+        userSide.createUser(
+            "Alice2", "9999 9999 9999", "LIC002", 26,
+            "alice2@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+    }
+
+    function test_createUser_revertsOnDuplicateEmailForPatient() public {
+        mediToken.mint(alice, 10);
+        mediToken.mint(bob, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "shared@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        vm.prank(bob);
+        vm.expectRevert("User with this wallet address or email already exists");
+        userSide.createUser(
+            "Bob", "9999 9999 9999", "LIC002", 30,
+            "shared@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+    }
+
+    // ─────────────────────────────────────────────
+    // approveUser
+    // ─────────────────────────────────────────────
+
+    function test_approveUser_onlyOwnerCanApprove() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Dr. Alice", "1234 5678 9012", "LIC001", 35,
+            "dr.alice@example.com", "Cardiology", "ipfs://img", "ipfs://deg", 2
+        );
+        vm.prank(bob);
+        vm.expectRevert();
+        userSide.approveUser(1);
+    }
+
+    function test_approveUser_setsVerifiedAndMappings() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Dr. Alice", "1234 5678 9012", "LIC001", 35,
+            "dr.alice@example.com", "Cardiology", "ipfs://img", "ipfs://deg", 2
+        );
+        vm.prank(owner);
+        userSide.approveUser(1);
+        uint256 userId = userSide.userWalletAddresstoUserId(alice);
+        assertEq(userId, 1);
+        (,,,,,,,,,, , bool isVerified) = userSide.userIdtoUser(1);
+        assertTrue(isVerified);
+    }
+
+    // ─────────────────────────────────────────────
+    // disApproveUser
+    // ─────────────────────────────────────────────
+
+    function test_disApproveUser_blacklistsUser() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        uint256 userId = userSide.userWalletAddresstoUserId(alice);
+        vm.prank(owner);
+        userSide.disApproveUser(userId);
+        assertTrue(userSide.userIdtoBlacklist(userId));
+        (,,,,,,,,,, , bool isVerified) = userSide.userIdtoUser(userId);
+        assertFalse(isVerified);
+    }
+
+    function test_disApproveUser_onlyOwner() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        vm.prank(bob);
+        vm.expectRevert();
+        userSide.disApproveUser(1);
+    }
+
+    // ─────────────────────────────────────────────
+    // reportUser
+    // ─────────────────────────────────────────────
+
+    function test_reportUser_incrementsReportCount() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        uint256 userId = userSide.userWalletAddresstoUserId(alice);
+        userSide.reportUser(userId);
+        assertEq(userSide.userIdtoReportUser(userId), 1);
+    }
+
+    function test_reportUser_blacklistsAfter100Reports() public {
+        mediToken.mint(alice, 10);
+        vm.prank(alice);
+        userSide.createUser(
+            "Alice", "1234 5678 9012", "LIC001", 25,
+            "alice@example.com", "General", "ipfs://img", "ipfs://deg", 3
+        );
+        uint256 userId = userSide.userWalletAddresstoUserId(alice);
+        for (uint256 i = 0; i <= 100; i++) {
+            userSide.reportUser(userId);
+        }
+        assertTrue(userSide.userIdtoBlacklist(userId));
+    }
+
+    // ─────────────────────────────────────────────
+    // getUserTokens
+    // ─────────────────────────────────────────────
+
+    function test_getUserTokens_returnsCorrectBalance() public {
+        mediToken.mint(alice, 42);
+        vm.prank(alice);
+        uint256 bal = userSide.getUserTokens();
+        assertEq(bal, 42);
+    }
+}


### PR DESCRIPTION
Closes #82

## Problem

- `MedETH/foundry/test/` directory did not exist, leaving `UserSide.sol` and `DoctorSide.sol` completely untested
- `foundry.toml` had a broken remapping — it mapped `openzeppelin=lib/openzeppelin-contracts` but both contracts import using the `@openzeppelin/contracts/...` prefix, meaning `forge build` could not resolve any OpenZeppelin import and the entire sub-project failed to compile

## Changes Made

**`MedETH/foundry/foundry.toml`**
- Corrected the remapping from `openzeppelin=lib/openzeppelin-contracts` to `@openzeppelin/contracts=lib/openzeppelin-contracts/contracts` so that all OpenZeppelin imports resolve correctly during `forge build` and `forge test`

**`MedETH/foundry/test/UserSide.t.sol`**
- MediToken balance gate on `createUser`
- Successful patient registration with wallet and email mapping
- Immediate verification for the Patient role
- Non-patient role registration flow
- Duplicate wallet address rejection
- Duplicate email rejection
- Owner-only access enforcement on `approveUser` and `disApproveUser`
- Blacklisting behaviour via `disApproveUser`
- Report count increment via `reportUser`
- Auto-blacklist trigger after 100 reports
- Correct balance return from `getUserTokens`

**`MedETH/foundry/test/DoctorSide.t.sol`**
- System Admin creation and approval inside the constructor
- `totalUsers` counter state after deployment
- Timeslot opening rejection for unverified users and non-doctor roles
- Successful timeslot creation by a verified doctor
- Standard appointment booking with the 5-token gate and blacklist checks
- Emergency appointment booking with the 10-token gate
- Appointment approval by the correct doctor
- Appointment approval rejection for the wrong caller
- Medical report upload verified against both the document counter and the patient report mapping length
- `MockMediToken` ERC20 contract included in both test files for local testing without deploying the real `MediToken`

## How It Solves The Problem

- `forge build` can now fully compile all contracts in `MedETH/foundry/src/`
- 28 new tests give complete behavioural coverage of both contracts so any future regression will be caught immediately by `forge test`
- The CI workflow added in PR #79 will now be able to run these tests automatically on every push

## Impact

- `forge build` now compiles successfully for the `MedETH/foundry` sub-project
- 28 new tests covering all core functions of `UserSide.sol` and `DoctorSide.sol`
- Future contributors have a working test baseline to build on