### PR TITLE
fix: replace hardcoded MediToken thresholds with configurable state variables and remove funding.json case collision

### DIFF
--- a/MedETH/foundry/src/DoctorSide.sol
+++ b/MedETH/foundry/src/DoctorSide.sol
@@ -8,6 +8,8 @@ contract DoctorSide is UserSide {
     uint256 public totalAppointments = 1;
     uint256 public totalDocuments = 1;
     uint256 public totalSlots = 1;
+    uint256 public appointmentFee = 5;
+    uint256 public emergencyAppointmentFee = 10;
 
     struct Appointment {
         uint256 appId;
@@ -144,10 +146,7 @@ contract DoctorSide is UserSide {
         appointmentIdtoAppointment[totalAppointments] = a1;
         uint256 patId = userWalletAddresstoUserId[msg.sender];
         uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
-        require(
-            i_mediToken.balanceOf(msg.sender) >= 5,
-            "You need to hold atleast 5 MediTokens to book an appointment"
-        );
+        require(i_mediToken.balanceOf(msg.sender) >= appointmentFee, "You need to hold atleast 5 MediTokens to book an appointment");
         require(
             patId != 0 && doctorId != 0,
             "Patient wallet address and wallet address must be both registered into the system"
@@ -170,10 +169,7 @@ contract DoctorSide is UserSide {
         address _doctorWalletAddress,
         uint256 _slotId
     ) public payable {
-        require(
-            i_mediToken.balanceOf(msg.sender) >= 10,
-            "You need to hold atleast 10 MediTokens to book an emergency appointment"
-        );
+        require(i_mediToken.balanceOf(msg.sender) >= emergencyAppointmentFee, "You need to hold atleast 10 MediTokens to book an emergency appointment");
         Appointment memory a1 = Appointment(
             totalAppointments,
             _appDate,
@@ -250,5 +246,10 @@ contract DoctorSide is UserSide {
         uint256 _doctorId
     ) public view returns (uint256) {
         return doctortIdtoReport[_doctorId].length;
+    }
+
+    function setAppointmentFee(uint256 _appointmentFee, uint256 _emergencyAppointmentFee) public onlyOwner {
+        appointmentFee = _appointmentFee;
+        emergencyAppointmentFee = _emergencyAppointmentFee;
     }
 }

--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,0 @@
-{
-  "opRetro": {
-    "projectId": "0x5cfdb8c453a7eede1946071e9d7417d01cc2116f57563b87dc0094a6bdb9a081"
-  }
-}


### PR DESCRIPTION
Closes #84

## Problem

While exploring the codebase as part of my DMP 2026 contribution, I found two independent housekeeping issues that affect maintainability and cross-platform compatibility.

The first issue is in `MedETH/foundry/src/DoctorSide.sol` where the `bookAppointment` and `bookAppointmentEmergency` functions use hardcoded values of `5` and `10` as the minimum MediToken balance required to book an appointment. These magic numbers are buried inside function bodies with no way to update them without modifying the contract source directly.

The second issue is that the repository has both `FUNDING.json` and `funding.json` tracked as separate entries in the Git index. On case-sensitive filesystems like Linux and macOS CI runners, Git correctly treats them as two distinct files. On Windows however, both paths resolve to the same physical file on disk, causing Git to constantly report one of them as `modified` even when no real changes have been made, creating persistent noise in `git status` and risking unintended commits on Windows machines.

## Changes Made

**`MedETH/foundry/src/DoctorSide.sol`**
- Added `uint256 public appointmentFee = 5;` and `uint256 public emergencyAppointmentFee = 10;` as public state variables so the thresholds are visible and readable on-chain
- Replaced the hardcoded `5` in `bookAppointment` with `appointmentFee`
- Replaced the hardcoded `10` in `bookAppointmentEmergency` with `emergencyAppointmentFee`
- Added a `setAppointmentFee(uint256 _appointmentFee, uint256 _emergencyAppointmentFee)` function with the `onlyOwner` modifier so the owner can update both thresholds in a single transaction without touching the contract source

**`funding.json`**
- Removed `funding.json` from the Git index using `git rm --cached` so only `FUNDING.json` remains tracked, eliminating the case collision and the persistent `modified` noise on Windows machines

## Impact

- Appointment fee thresholds are now configurable by the contract owner without redeployment
- The thresholds are publicly readable on-chain via `appointmentFee` and `emergencyAppointmentFee`
- `git status` on Windows will no longer show a phantom `modified` entry for the funding file
- CI runners on Linux and macOS will no longer have ambiguity about which file to use