### PR TITLE
fix: prevent double-booking of appointment slots in DoctorSide.sol

### DIFF
--- a/MedETH/foundry/src/DoctorSide.sol
+++ b/MedETH/foundry/src/DoctorSide.sol
@@ -128,20 +128,6 @@ contract DoctorSide is UserSide {
         address _doctorWalletAddress,
         uint256 _slotId
     ) public {
-        Appointment memory a1 = Appointment(
-            totalAppointments,
-            _appDate,
-            _startTime,
-            _endTime,
-            _appSubject,
-            _appFeedback,
-            msg.sender,
-            _doctorWalletAddress,
-            false,
-            _slotId,
-            0
-        );
-        appointmentIdtoAppointment[totalAppointments] = a1;
         uint256 patId = userWalletAddresstoUserId[msg.sender];
         uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
         require(
@@ -156,6 +142,30 @@ contract DoctorSide is UserSide {
             !userIdtoBlacklist[patId] && !userIdtoBlacklist[doctorId],
             "Either patient or doctor are blacklisted"
         );
+        require(
+            _slotId > 0 && _slotId < totalSlots,
+            "Invalid slot ID"
+        );
+        require(
+            !slotIdtoBookingStatus[_slotId],
+            "This slot is already booked"
+        );
+        slotIdtoBookingStatus[_slotId] = true;
+        appointmentSlotIdtoAppointmentSlot[_slotId].isBooked = true;
+        Appointment memory a1 = Appointment(
+            totalAppointments,
+            _appDate,
+            _startTime,
+            _endTime,
+            _appSubject,
+            _appFeedback,
+            msg.sender,
+            _doctorWalletAddress,
+            false,
+            _slotId,
+            0
+        );
+        appointmentIdtoAppointment[totalAppointments] = a1;
         docIdtoAppointmentId[doctorId].push(totalAppointments);
         patIdtoAppointmentId[patId].push(totalAppointments);
         totalAppointments++;
@@ -174,6 +184,26 @@ contract DoctorSide is UserSide {
             i_mediToken.balanceOf(msg.sender) >= 10,
             "You need to hold atleast 10 MediTokens to book an emergency appointment"
         );
+        uint256 patId = userWalletAddresstoUserId[msg.sender];
+        uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
+        require(
+            patId != 0 && doctorId != 0,
+            "Patient wallet address and wallet address must be both registered into the system"
+        );
+        require(
+            !userIdtoBlacklist[patId] && !userIdtoBlacklist[doctorId],
+            "Either patient or doctor are blacklisted"
+        );
+        require(
+            _slotId > 0 && _slotId < totalSlots,
+            "Invalid slot ID"
+        );
+        require(
+            !slotIdtoBookingStatus[_slotId],
+            "This slot is already booked"
+        );
+        slotIdtoBookingStatus[_slotId] = true;
+        appointmentSlotIdtoAppointmentSlot[_slotId].isBooked = true;
         Appointment memory a1 = Appointment(
             totalAppointments,
             _appDate,
@@ -188,16 +218,6 @@ contract DoctorSide is UserSide {
             1
         );
         appointmentIdtoAppointment[totalAppointments] = a1;
-        uint256 patId = userWalletAddresstoUserId[msg.sender];
-        uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
-        require(
-            patId != 0 && doctorId != 0,
-            "Patient wallet address and wallet address must be both registered into the system"
-        );
-        require(
-            !userIdtoBlacklist[patId] && !userIdtoBlacklist[doctorId],
-            "Either patient or doctor are blacklisted"
-        );
         docIdtoAppointmentId[doctorId].push(totalAppointments);
         patIdtoAppointmentId[patId].push(totalAppointments);
         totalAppointments++;


### PR DESCRIPTION
Fixes #73

While going through the appointment booking flow in DoctorSide.sol, I noticed that both bookAppointment and bookAppointmentEmergency had no guard against a slot being booked more than once. Any two patients could call either function with the same slotId at virtually the same time and both transactions would succeed, leaving the doctor with two confirmed appointments for the same window. That is the bug this PR addresses.

What I changed in bookAppointment and bookAppointmentEmergency:

First, I moved the patId and doctorId lookups to the top of the function so all the validation steps can use them without reading storage twice. Then I added two new require statements. The first one checks that the slotId passed in is within the valid range (greater than zero and less than totalSlots), so callers cannot reference a slot that was never opened. The second checks slotIdtoBookingStatus for that slot and reverts with a clear message if it is already taken.

Right after those checks pass, I set slotIdtoBookingStatus to true and flip the isBooked flag on appointmentSlotIdtoAppointmentSlot as well. Doing both atomically before the Appointment struct is even created means there is no window where a second concurrent transaction could slip through with the same slot.

The approveAppointment function already wrote to slotIdtoBookingStatus on approval, so that path remains consistent with no changes needed there.

How to verify: deploy the contract locally, open a slot, book it once successfully, then attempt to book the same slot again from a different account. The second call should revert with "This slot is already booked". Passing a slotId of zero or one beyond totalSlots should revert with "Invalid slot ID".