### PR TITLE
fix: add access control to uploadMedicalReprt to prevent forged medical records

### DIFF
--- a/MedETH/foundry/src/DoctorSide.sol
+++ b/MedETH/foundry/src/DoctorSide.sol
@@ -81,6 +81,29 @@ contract DoctorSide is UserSide {
         address _doctorWalletAddress,
         string memory _ipfsHash
     ) public {
+        require(
+            msg.sender == _doctorWalletAddress,
+            "Caller must be the doctor uploading the report"
+        );
+        uint256 doctorId = userWalletAddresstoUserId[msg.sender];
+        User memory doctor = userIdtoUser[doctorId];
+        require(
+            doctor.isVerified && doctor.userRole == 2,
+            "Only a verified doctor can upload medical reports"
+        );
+        require(
+            !userIdtoBlacklist[doctorId],
+            "Doctor is blacklisted"
+        );
+        uint256 patId = userWalletAddresstoUserId[_patientWalletAdress];
+        require(
+            patId != 0,
+            "Patient is not registered in the system"
+        );
+        require(
+            !userIdtoBlacklist[patId],
+            "Patient is blacklisted"
+        );
         PatientReport memory r1 = PatientReport(
             totalDocuments,
             _reportName,
@@ -89,8 +112,6 @@ contract DoctorSide is UserSide {
             _ipfsHash
         );
         ReportIdtoPatintReport[totalDocuments] = r1;
-        uint256 patId = userWalletAddresstoUserId[_patientWalletAdress];
-        uint256 doctorId = userWalletAddresstoUserId[_doctorWalletAddress];
         patientIdtoReport[patId].push(r1);
         doctortIdtoReport[doctorId].push(r1);
         totalDocuments++;


### PR DESCRIPTION
Fixes #65

When I was going through the DoctorSide contract I noticed that uploadMedicalReprt had no guards at all. Literally any externally owned account could call it, pass any patient address they wanted, and permanently write a fake medical record onto the chain. Since these records are treated as trusted medical evidence, this was a serious integrity problem that needed to be addressed properly.

The core issue was that the function accepted a _doctorWalletAddress parameter but never verified that the caller was actually that address, and never checked whether the caller was even a doctor in the system. It just wrote the report directly.

Here is what I added at the top of the function before any storage is touched:

The first check requires that msg.sender matches _doctorWalletAddress. This closes the impersonation vector entirely since you can never send a transaction as someone else on Ethereum.

The second check pulls the caller's user record and confirms they have userRole 2 and isVerified set to true. This mirrors exactly the same pattern already used in openTimeslots, so the fix is consistent with how the rest of the contract handles doctor authorization.

The third check confirms the doctor is not blacklisted, which prevents a banned account from still sneaking in reports.

The fourth and fifth checks verify that the patient address the report is being filed under actually belongs to a registered user who is also not blacklisted. This stops reports from being attached to phantom or banned accounts.

Only after all five checks pass is the PatientReport struct created and stored. I also moved the patId and doctorId lookups to the top alongside the new checks so the storage reads happen once and are reused throughout, keeping the gas cost clean.

How to verify: deploy the contract locally and try calling uploadMedicalReprt from a non-doctor wallet, from a blacklisted doctor, or with a patient address that is not registered. All three calls should revert. A call from a verified doctor for a registered patient should succeed and appear in both patientIdtoReport and doctortIdtoReport as expected.