### PR TITLE
fix: add missing RFC 5321 special characters to email regex in ZK circuits

### DIFF
--- a/zk-medical-billing-tracker/ZK-email-module/zk-email-verify/zk-email-verify/libs/regex_to_circom/regex_to_dfa.js
+++ b/zk-medical-billing-tracker/ZK-email-module/zk-email-verify/zk-email-verify/libs/regex_to_circom/regex_to_dfa.js
@@ -20,7 +20,7 @@ const catch_all =
 const catch_all_without_semicolon =
   "(0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z|A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z|!|\"|#|$|%|&|'|\\(|\\)|\\*|\\+|,|-|.|/|:|<|=|>|\\?|@|\\[|\\\\|\\]|^|_|`|{|\\||}|~| |\t|\n|\r|\x0b|\x0c)";
 
-const email_chars = `${alphanum}|_|.|-`;
+const email_chars = `${alphanum}|_|.|!|#|$|%|&|'|\\*|\\+|-|/|=|\\?|^|{|\\||}|~`;
 const base_64 = `(${alphanum}|\\+|/|=)`;
 const word_char = `(${alphanum}|_)`;
 
@@ -45,7 +45,7 @@ function test_regex() {
   // let to_from_regex_old = '(\r\n|\x80)(to|from):([A-Za-z0-9 _."@-]+<)?[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.]+>?\r\n';
   // let regex = `\r\ndkim-signature:(${key_chars}=${catch_all_without_semicolon}+; )+bh=${base_64}+; `;
   // let order_invariant_regex_raw = `((\\n|\x80|^)(((from):([A-Za-z0-9 _."@-]+<)?[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.]+>)?|(subject:[a-zA-Z 0-9]+)?|((to):([A-Za-z0-9 _."@-]+<)?[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.]+>)?|(dkim-signature:((a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z)=(0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z|A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z|!|"|#|$|%|&|\'|\\(|\\)|\\*|\\+|,|-|.|/|:|<|=|>|\\?|@|[|\\\\|]|^|_|`|{|\\||}|~| |\t|\n|\r|\x0B|\f)+; ))?)(\\r))+` // Uses a-z syntax instead of | for each char
-  let email_address_regex = `([a-zA-Z0-9._%\\+-=]+@[a-zA-Z0-9.-]+)`;
+  let email_address_regex = `([a-zA-Z0-9._%!#$&'\\*\\+\\-/=\\?^{\\|}~]+@[a-zA-Z0-9.-]+)`;
 
   // ------- HEADER/SIGNATURE REGEX --------
   let order_invariant_header_regex_raw = `(((\\n|^)(((from):([A-Za-z0-9 _."@-]+<)?[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.]+>)?|(subject:[a-zA-Z 0-9]+)?|((to):([A-Za-z0-9 _."@-]+<)?[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.]+>)?)(\\r))+)\\n`;
@@ -58,8 +58,6 @@ function test_regex() {
 
   // -------- SUBJECT REGEXES --------
   // This raw subject line (with \\ replaced with \) can be put into regexr.com to test new match strings and sanity check that it works
-  // TODO: Other valid chars in email addresses: #$%!^/&*, outlined at https://ladedu.com/valid-characters-for-email-addresses-the-complete-list/ and in the RFC
-
   // -- SEND SPECIFIC REGEXES --
   // let send_specific_raw_subject_regex = `((\r\n)|^)subject:[Ss]end (\$)?[0-9]+(.[0-9]+)? [a-zA-Z]+ to (${email_address_regex}|0x[0-9a-fA_F]+)\r\n`;
   // let raw_subject_regex = `((\r\n)|^)subject:[a-zA-Z]+ (\\$)?[0-9]+(.[0-9]+)? [a-zA-Z]+ to (([a-zA-Z0-9._%\\+-=]+@[a-zA-Z0-9.-]+)|0x[0-9]+)\r\n`;
@@ -72,7 +70,7 @@ function test_regex() {
   let raw_subject_regex = `((\r\n)|^)subject:[a-zA-Z]+ (\\$)?[0-9]+(.[0-9]+)? [a-zA-Z]+ to (${email_address_regex}|0x[0-9a-fA_F]+)\r\n`;
 
   // -------- OTHER FIELD REGEXES --------
-  let raw_from_regex = `(\r\n|^)from:([A-Za-z0-9 _.,"@-]+)<[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.-]+>\r\n`;
+  let raw_from_regex = `(\r\n|^)from:([A-Za-z0-9 _.,"@-]+)<[a-zA-Z0-9_.!#$&'\\*\\+/=\\?^{\\|}~-]+@[a-zA-Z0-9_.-]+>\r\n`;
   // let message_id_regex = `(\r\n|^)message-id:<[=@.\\+_-a-zA-Z0-9]+>\r\n`;
 
   // -------- TWITTER BODY REGEX ---------


### PR DESCRIPTION
## What this fixes

The email regex patterns inside `regex_to_dfa.js` have been silently rejecting valid email addresses for a while now. The local part of an email address (the part before the `@`) is allowed to contain a bunch of special characters per RFC 5321 Section 4.1.2, but our DFA generator only knew about a small handful of them.

Characters like `!`, `#`, `$`, `&`, `'`, `*`, `/`, `?`, `^`, `{`, `|`, `}`, and `~` are all perfectly legitimate in an unquoted email local part. If someone tried to generate a ZK proof for an email sent from or to an address that used any of these, the circuit generation step would fail not because anything was wrong with the email, just because we never told the DFA about those characters.

There was already a TODO comment in the file acknowledging this exact gap. This PR closes it.

## What changed

Three patterns were updated in `regex_to_dfa.js`:

**`email_chars`** is the reusable constant that describes what characters can appear in an email address. It previously only covered alphanumerics, underscore, dot, and hyphen. It now includes the full set of special characters the RFC permits.

**`email_address_regex`** is the pattern that gets compiled into the actual DFA used by the ZK circuit. The local-part character class was widened from `[a-zA-Z0-9._%\+-=]` to include all the missing RFC characters.

**`raw_from_regex`** parses the `From:` header and extracts the address inside angle brackets. The local-part there was even more restrictive than `email_address_regex` and has been brought in line with the same full set.

The TODO comment that tracked this issue has been removed since it is resolved.

## Why it matters

ZK email proofs are only as useful as the range of real-world emails they can handle. Healthcare providers and institutions often have email systems with non-trivial address formats, and a billing or verification system that silently chokes on a valid sender address is a real reliability problem. This brings the regex up to what the RFC actually says rather than what seemed common at the time.

## How to test

Generate a DFA for an email address that includes one of the previously unsupported characters, for example `user!billing@hospital.org` or `claims+dept#5@insurer.net`, and verify the resulting circuit accepts it. Previously both of those would have produced an incorrect DFA that rejected the address at proof generation time.

No existing tests are broken by this change since we are only expanding the accepted character set, not narrowing it.