### PR TITLE
fix: close the open-write vulnerability on patient medical history in UserSide.sol

### DIFF
--- a/MedETH/foundry/src/UserSide.sol
+++ b/MedETH/foundry/src/UserSide.sol
@@ -47,6 +47,9 @@ contract UserSide is Ownable {
     mapping(uint256 => string[]) public userIdtoPrevMedicalHistory;
     mapping(string => uint256) public userEmailtoUserId;
 
+    // Events
+    event PatientHistoryUpdated(uint256 indexed userId, address indexed updatedBy);
+
     // Constructor
     constructor(address _mediToken) Ownable(msg.sender) {
         i_mediToken = IERC20(_mediToken);
@@ -125,15 +128,35 @@ contract UserSide is Ownable {
         bool _isBp,
         bool _isDiabetes,
         uint256 _userExp
-    ) public {
+    ) internal {
         PatientHistory memory pt1 = PatientHistory(
-            totalUsers,
+            _userId,
             _isHandicap,
             _isBp,
             _isDiabetes,
             _userExp
         );
         userIdtoPatientHistory[_userId] = pt1;
+    }
+
+    function updateMyHistory(
+        bool _isHandicap,
+        bool _isBp,
+        bool _isDiabetes,
+        uint256 _userExp
+    ) public {
+        uint256 userId = userWalletAddresstoUserId[msg.sender];
+        require(userId != 0, "Caller is not a registered user");
+        require(userIdtoUser[userId].isVerified, "User account is not verified");
+        require(userIdtoUser[userId].userRole == 3, "Only patients can update their own history");
+        userIdtoPatientHistory[userId] = PatientHistory(
+            userId,
+            _isHandicap,
+            _isBp,
+            _isDiabetes,
+            _userExp
+        );
+        emit PatientHistoryUpdated(userId, msg.sender);
     }
 
     function approveUser(uint256 _userId) public onlyOwner {

--- a/MedETH/foundry/test/UserSide.t.sol
+++ b/MedETH/foundry/test/UserSide.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {UserSide} from "../src/UserSide.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockMediToken is ERC20 {
+    constructor() ERC20("MediToken", "MEDI") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract UserSideTest is Test {
+    UserSide public userSide;
+    MockMediToken public mediToken;
+
+    address public patient = address(0x1);
+    address public doctor = address(0x3);
+    address public stranger = address(0x4);
+
+    function setUp() public {
+        mediToken = new MockMediToken();
+        userSide = new UserSide(address(mediToken));
+
+        mediToken.mint(patient, 10);
+        mediToken.mint(doctor, 10);
+
+        vm.prank(patient);
+        userSide.createUser(
+            "Alice",
+            "1234 5678 9012",
+            "",
+            30,
+            "alice@test.com",
+            "",
+            "",
+            "",
+            3
+        );
+    }
+
+    function test_CreateUser_InitializesHistoryWithCorrectUserId() public view {
+        uint256 patientId = userSide.userWalletAddresstoUserId(patient);
+        (uint256 uid, bool isHandicap, bool isBp, bool isDiabetes, uint256 exp) =
+            userSide.userIdtoPatientHistory(patientId);
+
+        assertEq(uid, patientId);
+        assertFalse(isHandicap);
+        assertFalse(isBp);
+        assertFalse(isDiabetes);
+        assertEq(exp, 0);
+    }
+
+    function test_UpdateMyHistory_PatientCanUpdateOwnHistory() public {
+        uint256 patientId = userSide.userWalletAddresstoUserId(patient);
+
+        vm.prank(patient);
+        userSide.updateMyHistory(true, false, true, 5);
+
+        (uint256 uid, bool isHandicap, bool isBp, bool isDiabetes, uint256 exp) =
+            userSide.userIdtoPatientHistory(patientId);
+
+        assertEq(uid, patientId);
+        assertTrue(isHandicap);
+        assertFalse(isBp);
+        assertTrue(isDiabetes);
+        assertEq(exp, 5);
+    }
+
+    function test_UpdateMyHistory_EmitsPatientHistoryUpdatedEvent() public {
+        uint256 patientId = userSide.userWalletAddresstoUserId(patient);
+
+        vm.prank(patient);
+        vm.expectEmit(true, true, false, false);
+        emit UserSide.PatientHistoryUpdated(patientId, patient);
+        userSide.updateMyHistory(false, true, false, 2);
+    }
+
+    function test_UpdateMyHistory_RevertsForUnregisteredCaller() public {
+        vm.prank(stranger);
+        vm.expectRevert("Caller is not a registered user");
+        userSide.updateMyHistory(false, false, false, 0);
+    }
+
+    function test_UpdateMyHistory_RevertsForDisapprovedPatient() public {
+        uint256 patientId = userSide.userWalletAddresstoUserId(patient);
+        userSide.disApproveUser(patientId);
+
+        vm.prank(patient);
+        vm.expectRevert("User account is not verified");
+        userSide.updateMyHistory(false, false, false, 0);
+    }
+
+    function test_UpdateMyHistory_RevertsForNonPatientRole() public {
+        uint256 doctorId = userSide.totalUsers();
+        vm.prank(doctor);
+        userSide.createUser(
+            "Dr Bob",
+            "9876 5432 1098",
+            "LIC123",
+            40,
+            "bob@clinic.com",
+            "Cardiology",
+            "",
+            "",
+            2
+        );
+        userSide.approveUser(doctorId);
+
+        vm.prank(doctor);
+        vm.expectRevert("Only patients can update their own history");
+        userSide.updateMyHistory(false, false, false, 0);
+    }
+}

--- a/MedETH/frontend/src/utils/abis/usersideabi.json
+++ b/MedETH/frontend/src/utils/abis/usersideabi.json
@@ -169,13 +169,8 @@
     },
     {
         "type": "function",
-        "name": "takeUserHistory",
+        "name": "updateMyHistory",
         "inputs": [
-            {
-                "name": "_userId",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
             {
                 "name": "_isHandicap",
                 "type": "bool",
@@ -438,6 +433,25 @@
             }
         ],
         "stateMutability": "view"
+    },
+    {
+        "type": "event",
+        "name": "PatientHistoryUpdated",
+        "inputs": [
+            {
+                "name": "userId",
+                "type": "uint256",
+                "indexed": true,
+                "internalType": "uint256"
+            },
+            {
+                "name": "updatedBy",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
     },
     {
         "type": "event",


### PR DESCRIPTION
Closes #92

## What was broken

The `takeUserHistory` function in `UserSide.sol` was marked `public`. That one word meant that any wallet anywhere on the network could call it at any time, pass in any patient ID they wanted, and overwrite that patient's stored medical conditions with whatever values they chose. No check on who was calling. No check on whether they had any relationship to that patient. Nothing.

The `PatientHistory` struct stores whether a patient is handicapped, has blood pressure issues, or has diabetes. In a real deployment those flags would directly influence billing calculations, insurance logic, and clinical decisions. Any of that downstream logic would trust whatever was in storage without knowing it had been tampered with, because tampered data and legitimate data look identical on-chain.

There was also a secondary bug hiding in the same function. When building the `PatientHistory` struct, the code used `totalUsers` as the `userId` field instead of the `_userId` parameter that was actually passed in. When called from `createUser` this went unnoticed because both values happened to be equal at the time of the call. But it was wrong and has been corrected.

## What this PR does

**`takeUserHistory` is now `internal`.**

It was only ever called from within `createUser` anyway. There was never a legitimate external use case for it. Making it internal closes the attack surface entirely, the function simply cannot be reached from outside the contract anymore.

**`updateMyHistory` is added as the proper public replacement.**

Patients who genuinely need to record their own conditions now have a function designed for exactly that. It checks three things before writing anything:

1. The caller must be a registered user, meaning their wallet address maps to a non-zero userId.
2. That user account must be verified and approved.
3. The user must have role 3, which is patient. Doctors, admins, and hospital staff cannot call this, only the patient themselves.

If any of those checks fail the transaction reverts with a clear error message. If they all pass, the history is updated and a `PatientHistoryUpdated` event is emitted with the userId and the caller's address, so every single update is permanently recorded on-chain and auditable.

**The ABI is updated.**

The `takeUserHistory` entry has been removed since it is no longer externally callable. The new `updateMyHistory` function and the `PatientHistoryUpdated` event have been added so the frontend can use them immediately.

**Foundry tests are added.**

There was no test coverage for this contract at all before this PR. Five tests have been written covering the following scenarios:

- Patient registers and their history is initialized with the correct userId (this also validates the `totalUsers` bug fix)
- A verified patient successfully updates their own history and the stored values match what they sent
- Updating history emits the `PatientHistoryUpdated` event with the correct indexed parameters
- An unregistered wallet calling `updateMyHistory` reverts with the right message
- A disapproved patient calling `updateMyHistory` reverts because `isVerified` is false
- An approved doctor calling `updateMyHistory` reverts because role 2 is not role 3

## Files changed

`MedETH/foundry/src/UserSide.sol` is the main change. Three things happened: the event declaration was added, `takeUserHistory` became internal and had its struct bug fixed, and `updateMyHistory` was written below it.

`MedETH/foundry/test/UserSide.t.sol` is a new file. It creates a minimal mock ERC20 token, deploys the contract, and runs the five tests described above.

`MedETH/frontend/src/utils/abis/usersideabi.json` reflects the contract changes so the frontend does not break when it is rebuilt against the new contract.

## How to verify

Run `forge test` from the `MedETH/foundry` directory. All five tests should pass. You can also manually confirm that calling `takeUserHistory` from an external address no longer compiles or deploys successfully since the function is no longer part of the public interface.